### PR TITLE
feat: add dependency analysis for automatic version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# This configuration file enables Dependabot version updates.
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
+# https://github.com/dependabot/feedback/issues/551
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Documentation is important, and [Sphinx](https://www.sphinx-doc.org/en/master/) 
 
 Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/), and [Changelog](https://en.wikipedia.org/wiki/Changelog) generation are enabled using Github Actions (see [below](#versioning-publishing-and-changelog)).
 
+### Dependency Analysis
+
+[Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) is enabled to scan the dependencies and automatically create pull requests when an updated version is available.
+
 ### Standalone
 
 In addition to being an importable standard Python package, the package is also set up to be used as a runnable and standalone package using Python’s [-m](https://docs.python.org/3/using/cmdline.html#cmdoption-m) command-line option.

--- a/commitlint.rules.js
+++ b/commitlint.rules.js
@@ -1,7 +1,7 @@
 // See also .github/workflows/pull-request.yml
 module.exports = {
   rules: {
-    "subject-case": [2, "always", "sentence-case"],
-    "subject-max-length": [2, "always", 72],
+    "subject-max-length": [2, "always", 100],
+    "body-max-line-length": [2, "always", 200],
   },
 };


### PR DESCRIPTION
This PR sets up [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) to analyze dependencies for automatic version updates.

Because the current `commitlint` rules only accept `sentence-case` for commit `subject-case`, Dependabot's automatic commits would fail. That's because Dependabot uses `lower-case` when a `prefix` for the commit message is set. I have set the following prefixes to differentiate between the development and non-development modes:
```
  - prefix: "fix"
  - prefix-development: "chore"
```
Moreover, the `subject-max-length` and `body-max-line-length` are increased in the  `commitlint` rules because Dependabot's commit message lines or subjects can get long, e.g., 
```
chore(deps-dev): bump python-semantic-release from 7.16.2 to 7.19.2
``` 
Note that the current configuration only enables updates for `pip` and `github-actions` package ecosystems.

Finally, this PR updates the README.md file to document the dependency analysis feature.