### PR TITLE
feat: add type stubs for the example package

### DIFF
--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -10,7 +10,7 @@ The badges above give you an idea of what this project template provides. It’s
 
 ### Typing
 
-The package requires a minimum of [Python 3.9](https://www.python.org/downloads/release/python-390/) and supports [Python 3.10](https://www.python.org/downloads/release/python-3100/). All code requires comprehensive [typing](https://docs.python.org/3/library/typing.html). The [mypy](http://mypy-lang.org/) static type checker is invoked by a git hook and through a Github Action to enforce continuous type checks.
+The package requires a minimum of [Python 3.9](https://www.python.org/downloads/release/python-390/) and supports [Python 3.10](https://www.python.org/downloads/release/python-3100/). All code requires comprehensive [typing](https://docs.python.org/3/library/typing.html). The [mypy](http://mypy-lang.org/) static type checker is invoked by a git hook and through a Github Action to enforce continuous type checks. Make sure to add type hints to your code or to use [stub files](https://mypy.readthedocs.io/en/stable/stubs.html) for types, to ensure that users of your package can `import` and type-check your code (see also [PEP 561](https://www.python.org/dev/peps/pep-0561/)).
 
 ### Quality Assurance
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setuptools.setup(
         "docs": ["sphinx==4.3.0"],
     },
     package_data={
-        "package": ["py.typed", "*.pyi"],
+        "package": ["py.typed"],
     },
     options={},
     platforms="",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,9 @@ setuptools.setup(
         ],
         "docs": ["sphinx==4.3.0"],
     },
-    package_data={},
+    package_data={
+        "package": ["py.typed", "*.pyi"],
+    },
     options={},
     platforms="",
     zip_safe=False,

--- a/src/package/__init__.pyi
+++ b/src/package/__init__.pyi
@@ -1,0 +1,2 @@
+# The package version's type is the only one here.
+__version__: str

--- a/src/package/__init__.pyi
+++ b/src/package/__init__.pyi
@@ -1,2 +1,0 @@
-# The package version's type is the only one here.
-__version__: str

--- a/src/package/something.pyi
+++ b/src/package/something.pyi
@@ -1,0 +1,4 @@
+# Type stub for the Something class.
+class Something:
+    @staticmethod
+    def do_something(value: bool = ...) -> bool: ...

--- a/src/package/something.pyi
+++ b/src/package/something.pyi
@@ -1,4 +1,0 @@
-# Type stub for the Something class.
-class Something:
-    @staticmethod
-    def do_something(value: bool = ...) -> bool: ...


### PR DESCRIPTION
Closes #54 and adds [PEP 561](https://www.python.org/dev/peps/pep-0561/) compatible type stubs so that `mypy` is able to check code which imports this package correctly.

I’ve tested this by creating an external test venv and `pip install`ed this cookiecutter template package. Without the changes of this PR I get
```
(TEST) savage@pooh ~/opt/dev/TEST > mypy test.py 
test.py:1: error: Skipping analyzing "package.something": found module but no type hints or library stubs
test.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
test.py:1: error: Skipping analyzing "package": found module but no type hints or library stubs
Found 2 errors in 1 file (checked 1 source file)
```
whereas with this change
```
(TEST) savage@pooh ~/opt/dev/TEST > mypy test.py 
Success: no issues found in 1 source file
```

Note: `black` picked up the `*.pyi` files, but I am not sure whether `pylint` did (see issues https://github.com/PyCQA/pylint/issues/2873), and it looks like `flake8` did not (see [flake8-pyi](https://github.com/ambv/flake8-pyi) plugin).