### PR TITLE
ci: remove unnecessary semantic-release tool from dev environment

### DIFF
--- a/.github/workflows/check-and-release-main.yml
+++ b/.github/workflows/check-and-release-main.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Python Semantic Release
-      uses: relekang/python-semantic-release@master
+      uses: relekang/python-semantic-release@v7.23.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         pypi_token: ""  # We don't publish to PyPi: ${{ secrets.PYPI_TOKEN }}

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -151,9 +151,10 @@ To enable automation for versioning, package publishing, and changelog generatio
 
 For more configuration options, please refer to the `tool.semantic_release` section in the `pyproject.toml` file, and read the [semantic release documentation](https://python-semantic-release.readthedocs.io/en/latest/).
 
-You can also run the tool manually, for example:
+You can also install and run the tool manually, for example:
 
 ```bash
+pip install python-semantic-release
 semantic-release changelog
 semantic-release version
 ```

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setuptools.setup(
             "pep8-naming==0.12.1",
             "pre-commit==2.16.0",
             "pylint==2.12.2",
-            "python-semantic-release==7.23.0",
             "tox==3.24.4",
         ],
         "docs": ["sphinx==4.3.1"],


### PR DESCRIPTION
This PR closes #62 but I wanted to discuss some more. Specifying

https://github.com/jenstroeger/python-package-template/blob/de5c51b08c6bd97880cc24594a928e19c5932ecb/.github/workflows/check-and-release-main.yml#L44

doesn’t actually _pin_ a version and instead every run of this Action uses whatever changes are at the head of the `master` branch. That, I think, violates some of the [SLSA build requirements](https://slsa.dev/requirements#build-requirements) like “Reproducible”.

📌 it?