### PR TITLE
ci: add bandit to pre-commit hooks to check for common security issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,15 +70,6 @@ repos:
     files: ^src/package/|^tests/|setup.py
     args: [--config-file, mypy.ini]
 
-# Check for various security problems.
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.1
-  hooks:
-  - id: bandit
-    files: ^src/package/|^tests/|setup.py
-    args: [--skip, "B101"]
-    # args: [--configfile, pyproject.toml]
-
 # Enable a whole bunch of useful helper hooks, too.
 # See https://pre-commit.com/hooks.html for more hooks.
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,15 @@ repos:
     files: ^src/package/|^tests/|setup.py
     args: [--config-file, mypy.ini]
 
+# Check for various security problems.
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.1
+  hooks:
+  - id: bandit
+    files: ^src/package/|^tests/|setup.py
+    args: [--skip, "B101"]
+    # args: [--configfile, pyproject.toml]
+
 # Enable a whole bunch of useful helper hooks, too.
 # See https://pre-commit.com/hooks.html for more hooks.
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -14,7 +14,7 @@ The package requires a minimum of [Python 3.9](https://www.python.org/downloads/
 
 ### Quality Assurance
 
-A number of git hooks are invoked before and after a commit, and before push. These hooks are all managed by the [pre-commit](https://pre-commit.com/) tool and enforce a number of [software quality assurance](https://en.wikipedia.org/wiki/Software_quality_assurance) measures (see [below](#git-hooks)).
+A number of git hooks are invoked before and after a commit, and before push. These hooks are all managed by the [pre-commit](https://pre-commit.com/) tool and enforce a number of [software quality assurance](https://en.wikipedia.org/wiki/Software_quality_assurance) measures (see [below](#git-hooks)). Additionally, the [bandit](https://github.com/PyCQA/bandit) tools is being installed as part of a development environment (i.e. the `[dev]` package extra); however, bandit does not run automatically!
 
 ### Unit testing
 

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -14,7 +14,7 @@ The package requires a minimum of [Python 3.9](https://www.python.org/downloads/
 
 ### Quality Assurance
 
-A number of git hooks are invoked before and after a commit, and before push. These hooks are all managed by the [pre-commit](https://pre-commit.com/) tool and enforce a number of [software quality assurance](https://en.wikipedia.org/wiki/Software_quality_assurance) measures (see [below](#git-hooks)). Additionally, the [bandit](https://github.com/PyCQA/bandit) tools is being installed as part of a development environment (i.e. the `[dev]` package extra); however, bandit does not run automatically!
+A number of git hooks are invoked before and after a commit, and before push. These hooks are all managed by the [pre-commit](https://pre-commit.com/) tool and enforce a number of [software quality assurance](https://en.wikipedia.org/wiki/Software_quality_assurance) measures (see [below](#git-hooks)).
 
 ### Unit testing
 
@@ -34,7 +34,13 @@ Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/
 
 ### Security Analysis
 
-[Codeql](https://codeql.github.com/) is enabled to scan the Python code for security vulnerabilities. You can adjust the GitHub Actions workflow at `.github/workflows/codeql-analysis.yml` and the configuration file at `.github/codeql/codeql-config.yml` to add more languages, change the default paths, scan schedule, and queries.
+[CodeQL](https://codeql.github.com/) is enabled to scan the Python code for security vulnerabilities. You can adjust the GitHub Actions workflow at `.github/workflows/codeql-analysis.yml` and the configuration file at `.github/codeql/codeql-config.yml` to add more languages, change the default paths, scan schedule, and queries.
+
+Additionally, the [bandit](https://github.com/PyCQA/bandit) tool is being installed as part of a development environment (i.e. the `[dev]` package extra); however, bandit does not run automatically! Instead, you can invoke it manually:
+
+```bash
+bandit --recursive src  # Add '--skip B101' when checking the tests, Bandit issue #457.
+```
 
 ### Standalone
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ skip_gitignore = true
 line-length = 120
 target-version = ["py39"]
 
+# https://bandit.readthedocs.io/en/latest/config.html
+[tool.bandit]
+tests = []
+skips = ["B101"]
+
 # https://docs.pytest.org/en/6.2.x/customize.html#configuration-file-formats
 # https://docs.pytest.org/en/6.2.x/reference.html#configuration-options
 # https://docs.pytest.org/en/6.2.x/reference.html#command-line-flags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ line-length = 120
 target-version = ["py39"]
 
 # https://bandit.readthedocs.io/en/latest/config.html
+# Skip test B101 because of issue https://github.com/PyCQA/bandit/issues/457
 [tool.bandit]
 tests = []
 skips = ["B101"]

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setuptools.setup(
     extras_require={
         "test": ["hypothesis==6.35.0", "pytest==6.2.5", "pytest-cov==3.0.0"],
         "dev": [
+            "bandit==1.7.1",
             "flake8==4.0.1",
             "flake8-builtins==1.5.3",
             "flake8-docstrings==1.6.0",


### PR DESCRIPTION
As mentioned in issue #5 I added the [bandit](https://bandit.readthedocs.io/) tool as a pre-commit hook.

I do have a few concerns though:
- There are currently 146 open issues and 48 open pull requests, and progress seems sluggish.
- `pyproject.toml` configuration isn’t currently supported (issue https://github.com/PyCQA/bandit/issues/733) but seems to have been committed to mainstream (commit https://github.com/PyCQA/bandit/commit/44f5c416cc0b7d62ca55b78e90bd1f7ee3d16082) but I couldn’t make that work.
- Our unit tests make explicit use of the [assert](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement) statement which is flagged by `bandit` as [issue B101](https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html), and it’s not possible to disable that for tests only (issue https://github.com/PyCQA/bandit/issues/457); so I’ve disabled it globally through the command-line (because the `pyproject.toml` isn’t working).

So, while I think that `bandit` can be useful, in its current state it’s a bit limited and inflexible for CI.