### PR TITLE
chore: make sure to always show certain warnings when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
 # Use pytest for testing and set up an optional environment for it.
 [testenv]
 extras = test
-commands = pytest
+commands = python -W always::DeprecationWarning -m pytest
 setenv =
     SOME_VAR = "value"
 


### PR DESCRIPTION
I think it makes sense to _always_ show certain runtime exceptions, e.g. a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). We may want to document this, and we may consider using the [-W](https://docs.python.org/3/using/cmdline.html#cmdoption-W) option to raise exceptions and actually fail a `tox` run?