### PR TITLE
feat: enable codeql security analyzer

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
-name: "My CodeQL config"
+name: CodeQL config
 
 paths:
-  - src/package
+- src/package

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "My CodeQL config"
+
+paths:
+  - src/package

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,20 +1,19 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
     branches:
-      - main
-      - staging
+    - main
+    - staging
   pull_request:
     branches:
-      - main
-      - staging
+    - main
+    - staging
     # Avoid unnecessary scans of pull requests.
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
+    paths:
+    - '**/*.py'
   schedule:
-    - cron: '20 15 * * 3'
+  - cron: 20 15 * * 3
 
 jobs:
   analyze:
@@ -28,10 +27,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: [python]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-        python: ["3.9", "3.10"]
+        python: ['3.9', '3.10']
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,64 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+    # Avoid unnecessary scans of pull requests.
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+  schedule:
+    - cron: '20 15 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        python: ["3.9", "3.10"]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install .[test,dev]
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
+        # Override the default behavior so that the action doesn't attempt
+        # to auto-install Python dependencies
+        setup-python-dependencies: false
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -34,7 +34,7 @@ Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/
 
 ### Security Analysis
 
-[Codeql](https://codeql.github.com/) is enabled to scan the Python code for security vulnerabilities. You can adjust the GitHub Actions workflow at `.github/workflows/codeql-analysis.yml` and the configuration file at `.github/codeql/codeql-config.yml`to add more languages, change the default paths, scan schedule, and queries.
+[Codeql](https://codeql.github.com/) is enabled to scan the Python code for security vulnerabilities. You can adjust the GitHub Actions workflow at `.github/workflows/codeql-analysis.yml` and the configuration file at `.github/codeql/codeql-config.yml` to add more languages, change the default paths, scan schedule, and queries.
 
 ### Standalone
 

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -32,6 +32,10 @@ Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/
 
 [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) is enabled to scan the dependencies and automatically create pull requests when an updated version is available.
 
+### Security Analysis
+
+[Codeql](https://codeql.github.com/) is enabled to scan the Python code for security vulnerabilities. You can adjust the GitHub Actions workflow at `.github/workflows/codeql-analysis.yml` and the configuration file at `.github/codeql/codeql-config.yml`to add more languages, change the default paths, scan schedule, and queries.
+
 ### Standalone
 
 In addition to being an importable standard Python package, the package is also set up to be used as a runnable and standalone package using Python’s [-m](https://docs.python.org/3/using/cmdline.html#cmdoption-m) command-line option.


### PR DESCRIPTION
This PR enables Codeql for analyzing the python code in `src/package` directory. The current settings force the scan for PRs and `push`es to the `main` and `staging` branches. It's also scheduled to run once a week. It does not trigger on PRs that only modify `.txt` or `.md` files.

Note that Codeql is not supported in private repositories by default. 