### PR TITLE
chore: lint and reformat the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,24 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
-    open-pull-requests-limit: 13
-    target-branch: "staging"
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: daily
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 13
+  target-branch: staging
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
-    open-pull-requests-limit: 13
-    target-branch: "staging"
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  commit-message:
+    prefix: fix
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 13
+  target-branch: staging


### PR DESCRIPTION
Cleans up and reformats the Dependabot config using [pretty-format-yaml](https://github.com/macisamuele/language-formatters-pre-commit-hooks).