### PR TITLE
fix: remove exclude from mypy.ini and update version

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,9 +3,10 @@
 
 # Specify the target platform details in config, so developers
 # get consistent results on any platform.
-python_version=3.10
+python_version=3.9
 platform=linux
 mypy_path=src
+# exclude=
 
 # Useful settings.
 show_column_numbers=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,10 +3,9 @@
 
 # Specify the target platform details in config, so developers
 # get consistent results on any platform.
-python_version=3.9
+python_version=3.10
 platform=linux
 mypy_path=src
-exclude=
 
 # Useful settings.
 show_column_numbers=True


### PR DESCRIPTION
By removing `exclude=` mypy can find the files again and the CI should pass.

This PR also updates the Python version to `3.10`.