### PR TITLE
chore: improve `mypy` error messages

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,7 @@ mypy_path=src
 
 # Useful settings.
 show_column_numbers=True
+show_error_codes=True
 check_untyped_defs=True
 
 # And some more warnings.


### PR DESCRIPTION
This change adds [mypy error codes](https://mypy.readthedocs.io/en/stable/error_codes.html) to the error messages, which are then used to ignore only those messages; required by the `python-check-blanket-type-ignore` commit hook.