### PR TITLE
chore: add “bump” type to release commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,5 @@ testpaths = [
 branch = "main"
 version_variable = "src/package/__init__.py:__version__"
 upload_to_pypi = false
-commit_subject = "chore: Release v{version}"
+commit_subject = "bump: release v{version}"
 changelog_file = "CHANGELOG.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,5 @@ testpaths = [
 branch = "main"
 version_variable = "src/package/__init__.py:__version__"
 upload_to_pypi = false
-commit_subject = "Release v{version}"
+commit_subject = "chore: Release v{version}"
 changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
commit_subject for semantic-release version command must have proper convention