### PR TITLE
chore: add useful comment to PEP-561 type marker

### DIFF
--- a/src/package/py.typed
+++ b/src/package/py.typed
@@ -1,0 +1,1 @@
+# PEP-561 marker. https://mypy.readthedocs.io/en/latest/installed_packages.html


### PR DESCRIPTION
I liked how @bringhurst added a comment to the type marker in PR https://github.com/madzak/python-json-logger/pull/129, and I’m stealing that approach here 🤓