### PR TITLE
ci: add Release Notification action

### DIFF
--- a/.github/workflows/release-notifications.yaml
+++ b/.github/workflows/release-notifications.yaml
@@ -1,0 +1,30 @@
+name: Release Notifications
+on:
+  release:
+    types: [published]
+jobs:
+  slack:
+    name: Slack release notification
+    # Remove the next line after your Slack app has been set up. See also:
+    # https://github.com/slackapi/slack-github-action#setup-2
+    if: ${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: slackapi/slack-github-action@v1.18.0
+      with:
+        payload: |
+          {
+            "text": "${{ github.event.repository.name }} published a new release ${{ github.event.release.tag_name }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*${{ github.event.repository.name }}* published a new release <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}>"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release-notifications.yaml
+++ b/.github/workflows/release-notifications.yaml
@@ -2,15 +2,21 @@ name: Release Notifications
 on:
   release:
     types: [published]
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   slack:
     name: Slack release notification
     # Remove the next line after your Slack app has been set up. See also:
     # https://github.com/slackapi/slack-github-action#setup-2
     if: ${{ false }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: slackapi/slack-github-action@v1.18.0
+    - uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
       with:
         payload: |
           {

--- a/.github/workflows/release-notifications.yaml
+++ b/.github/workflows/release-notifications.yaml
@@ -3,8 +3,8 @@ on:
   release:
     types: [published]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Grant no permissions to this workflow.
+permissions: {}
 
 jobs:
   slack:
@@ -12,8 +12,6 @@ jobs:
     # Remove the next line after your Slack app has been set up. See also:
     # https://github.com/slackapi/slack-github-action#setup-2
     if: ${{ false }}
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -44,7 +44,7 @@ Documentation is important, and [Sphinx](https://www.sphinx-doc.org/en/master/) 
 
 ### Versioning and publishing
 
-Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/), and [Changelog](https://en.wikipedia.org/wiki/Changelog) generation are enabled using Github Actions (see [below](#versioning-publishing-and-changelog)).
+Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/), and [Changelog](https://en.wikipedia.org/wiki/Changelog) generation are enabled using Github Actions. Furthermore, an optional [Release Notification](https://github.com/jenstroeger/python-package-template/tree/main/.github/workflows/release-notifications.yaml) Action allows Github to push an update notification to a [Slack bot](https://api.slack.com/bot-users) of your choice. For setup instructions, please see [below](#versioning-publishing-and-changelog).
 
 ### Dependency analysis
 
@@ -182,6 +182,8 @@ semantic-release version
 ```
 
 Use the `--verbosity=DEBUG` command-line argument for more details.
+
+If you’d like to receive Slack notifications whenever a new release is published, follow the comments in the [Release Notification](https://github.com/jenstroeger/python-package-template/tree/main/.github/workflows/release-notifications.yaml) Action and set up a Slack bot by following [the instructions here](https://github.com/slackapi/slack-github-action#setup-2).
 
 ## Frequently asked questions
 


### PR DESCRIPTION
This change adds a new Github Action for the [Release Event](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#releaseevent): when a release is published (either manually through the Github website or through another Action) then this action sends out a Slack notification.

Because we don’t actually have a Slack workspace with this repository, the Action’s `slack` job is being skipped:

https://github.com/jenstroeger/python-package-template/blob/06319c75a537cf6df8d98bb71637c79b93e7ced0/.github/workflows/release-notifications.yaml#L8-L10

For now this PR is a **Draft** because we should probably document this feature in the [README.md](https://github.com/jenstroeger/python-package-template/blob/main/UPSTREAM_README.md)…