### PR TITLE
chore: adjust Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,9 +7,9 @@ updates:
 - package-ecosystem: pip
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
   commit-message:
-    prefix: fix
+    prefix: chore
     prefix-development: chore
     include: scope
   open-pull-requests-limit: 13
@@ -18,9 +18,9 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
   commit-message:
-    prefix: fix
+    prefix: chore
     prefix-development: chore
     include: scope
   open-pull-requests-limit: 13


### PR DESCRIPTION
Changes the Dependabot configuration to run the checks weekly instead of daily. Also changes the `fix` commit message scopes to `chore`.