### PR TITLE
fix: fix "make dist" failing on latest version of Ubuntu

### DIFF
--- a/.github/workflows/check-and-release-main.yaml
+++ b/.github/workflows/check-and-release-main.yaml
@@ -28,6 +28,10 @@ jobs:
       run: make check
     - name: Run tests
       run: make test
+    - name: Build the package
+      run: make dist
+    - name: Build the docs
+      run: make docs
   release:
     needs: check
     name: Release

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setuptools.setup(
             "pep8-naming==0.12.1",
             "pylint>=2.9.3,<=2.13.8",
             "types-setuptools>=57.4.7,<=57.4.14",
+            "wheel==0.37.1",
         ],
         "docs": [
             "sphinx>=4.1.2,<=4.5.0",


### PR DESCRIPTION
This PR installs the `wheel` package which is necessary for running `python setup.py bdist_wheel` ([make dist](https://github.com/jenstroeger/python-package-template/blob/add-wheel/Makefile#L100)) on latest version of Ubuntu. It also adds new steps to the CI workflow to test the the build.