### PR TITLE
chore: add security policy, elaborate on test policy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include src/package *
 recursive-exclude src/package/**/__pycache__ *
 
 exclude .gitignore .pre-commit-config.yaml .flake8
-exclude CHANGELOG.md SECURITY.md MANIFEST.in UPSTREAM_README.md UPSTREAM_CHANGELOG.md Makefile
+exclude CHANGELOG.md SECURITY.md MANIFEST.in UPSTREAM_README.md UPSTREAM_CHANGELOG.md UPSTREAM_SECURITY.md Makefile
 exclude commitlint.rules.js mypy.ini pylintrc pyproject.toml
 recursive-exclude .github *
 recursive-exclude docs *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include src/package *
 recursive-exclude src/package/**/__pycache__ *
 
 exclude .gitignore .pre-commit-config.yaml .flake8
-exclude CHANGELOG.md MANIFEST.in UPSTREAM_README.md UPSTREAM_CHANGELOG.md Makefile
+exclude CHANGELOG.md SECURITY.md MANIFEST.in UPSTREAM_README.md UPSTREAM_CHANGELOG.md Makefile
 exclude commitlint.rules.js mypy.ini pylintrc pyproject.toml
 recursive-exclude .github *
 recursive-exclude docs *

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-This is a package template repository, and thus does not support different versions; instead, only the latest version of this repository is being maintained. Adjust this policy to your needs if your build on this repository. For more information, please refer to GitHub’s [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+This is a package template repository, and thus does not support different versions; instead, only the latest version of this repository is being maintained. Adjust this policy to your needs if you build on this repository. For more information, please refer to GitHub’s [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
 
 ## Supported Versions
 
@@ -13,4 +13,4 @@ Only current major version:
 
 ## Reporting a Vulnerability
 
-Please create a [new issue](https://github.com/jenstroeger/python-package-template/issues/new) if you find a security vulnerablity in this repository.
+Please create a [new issue](https://github.com/jenstroeger/python-package-template/issues/new) if you find a security vulnerability in this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,1 @@
-# Security Policy
-
-This is a package template repository, and thus does not support different versions; instead, only the latest version of this repository is being maintained. Adjust this policy to your needs if you build on this repository. For more information, please refer to GitHub’s [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
-
-## Supported Versions
-
-Only current major version:
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| 0.x.x   | :x:                |
-
-## Reporting a Vulnerability
-
-Please create a [new issue](https://github.com/jenstroeger/python-package-template/issues/new) if you find a security vulnerability in this repository.
+UPSTREAM_SECURITY.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+This is a package template repository, and thus does not support different versions; instead, only the latest version of this repository is being maintained. Adjust this policy to your needs if your build on this repository. For more information, please refer to GitHub’s [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+
+## Supported Versions
+
+Only current major version:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| 0.x.x   | :x:                |
+
+## Reporting a Vulnerability
+
+Please create a [new issue](https://github.com/jenstroeger/python-package-template/issues/new) if you find a security vulnerablity in this repository.

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -194,7 +194,7 @@ Required test coverage of 100.0% reached. Total coverage: 100.00%
 
 ============================== 1 passed in 0.16s ===============================
 ```
-Note that code that’s not covered by tests is listed under the `Missing` column.
+Note that code that’s not covered by tests is listed under the `Missing` column. The net effect of enforcing 100% code coverage is that every new major or minor feature, every code change, and every fix are being tested (keeping in mind that _code coverage_ does not correlate with _test quality_).
 
 Hypothesis is a package that implements [property based testing](https://en.wikipedia.org/wiki/QuickCheck) and that provides payload generation for your tests based on strategy descriptions ([more](https://hypothesis.works/#what-is-hypothesis)). Using its [pytest plugin](https://hypothesis.readthedocs.io/en/latest/details.html#the-hypothesis-pytest-plugin) Hypothesis is ready to be used for this package.
 

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -194,7 +194,7 @@ Required test coverage of 100.0% reached. Total coverage: 100.00%
 
 ============================== 1 passed in 0.16s ===============================
 ```
-Note that code that’s not covered by tests is listed under the `Missing` column. The net effect of enforcing 100% code coverage is that every new major or minor feature, every code change, and every fix are being tested (keeping in mind that _code coverage_ does not correlate with _test quality_).
+Note that code that’s not covered by tests is listed under the `Missing` column. The net effect of enforcing 100% code coverage is that every new major and minor feature, every code change, and every fix are being tested (keeping in mind that _code coverage_ does not correlate with _test quality_).
 
 Hypothesis is a package that implements [property based testing](https://en.wikipedia.org/wiki/QuickCheck) and that provides payload generation for your tests based on strategy descriptions ([more](https://hypothesis.works/#what-is-hypothesis)). Using its [pytest plugin](https://hypothesis.readthedocs.io/en/latest/details.html#the-hypothesis-pytest-plugin) Hypothesis is ready to be used for this package.
 

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -80,7 +80,7 @@ If you’d like to contribute to the project template, please open an issue for 
 
 If you’d like to start your own Python project from scratch, you can either copy the content of this repository into your new project folder or fork this repository. Either way, consider making the following adjustments to your local copy:
 
-- Change the `LICENSE.md` file and the license badge according to your needs, replace the [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) `README.md` with an actual README file, and similarly replace the symbolic link `CHANGELOG.md` with an actual CHANGELOG file which contains a single line:
+- Change the `LICENSE.md` file and the license badge according to your needs, replace the [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) `README.md` with an actual README file, likewise replace the symbolic link `SECURITY.md` with a SECURITY file adjusted to your needs (more details [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)), and lastly replace the symbolic link `CHANGELOG.md` with an actual CHANGELOG file which contains a single line:
 
   ```markdown
   <!--next-version-placeholder-->

--- a/UPSTREAM_SECURITY.md
+++ b/UPSTREAM_SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+This is a package template repository, and thus does not support different versions; instead, only the latest version of this repository is being maintained. Adjust this policy to your needs if you build on this repository. For more information, please refer to GitHub’s [Adding a security policy to your repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+
+## Supported Versions
+
+Only current major version:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| 0.x.x   | :x:                |
+
+## Reporting a Vulnerability
+
+Please create a [new issue](https://github.com/jenstroeger/python-package-template/issues/new) if you find a security vulnerability in this repository.

--- a/src/package/__init__.py
+++ b/src/package/__init__.py
@@ -6,4 +6,4 @@ This package is an empty cookiecutter package example. Enjoy!
 # The version of this package. There's no comprehensive, official list of other
 # magic constants, so we stick with this one only for now. See also this conversation:
 # https://stackoverflow.com/questions/38344848/is-there-a-comprehensive-table-of-pythons-magic-constants
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/src/package/__init__.py
+++ b/src/package/__init__.py
@@ -6,4 +6,4 @@ This package is an empty cookiecutter package example. Enjoy!
 # The version of this package. There's no comprehensive, official list of other
 # magic constants, so we stick with this one only for now. See also this conversation:
 # https://stackoverflow.com/questions/38344848/is-there-a-comprehensive-table-of-pythons-magic-constants
-__version__ = "1.4.1"
+__version__ = "1.4.0"


### PR DESCRIPTION
Based on code-scanning feedback for https://github.com/jenstroeger/python-package-template/security/code-scanning/36 and issue https://github.com/jenstroeger/python-package-template/issues/13, this change [adds a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) to our template repo.