### PR TITLE
ci: add Bandit security checker to git commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,16 @@ repos:
     files: ^src/package/|^tests/
     args: [--config-file, pyproject.toml]
 
+# Check for potential security issues.
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.4
+  hooks:
+  - id: bandit
+    name: Check for security issues
+    args: [--configfile, pyproject.toml]
+    files: ^src/package/|^tests/
+    additional_dependencies: ['bandit[toml]']
+
 # Enable a whole bunch of useful helper hooks, too.
 # See https://pre-commit.com/hooks.html for more hooks.
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -58,12 +58,6 @@ Automatic package versioning and tagging, publishing to [PyPI](https://pypi.org/
 
 [OSSF Security Scorecards](https://github.com/ossf/scorecard) is enabled as a GitHub Actions workflow to give the consumers information about the supply-chain security posture of this project, assigning a score of 0–10. We upload the results as a SARIF (Static Analysis Results Interchange Format) artifact after each run and the results can be found at the Security tab of this GitHub project. We also allow publishing the data at [OpenSSF](https://metrics.openssf.org/). We use this data to continuously improve the security posture of this project. Note that this configuration supports the ``main`` (default) branch and requires the repository to be public and not forked.
 
-Additionally, the [bandit](https://github.com/PyCQA/bandit) tool is being installed as part of a development environment (i.e. the `[dev]` package extra); however, bandit does not run automatically! Instead, you can invoke it manually:
-
-```bash
-bandit --recursive src  # Add '--skip B101' when checking the tests, Bandit issue #457.
-```
-
 ### Package or application?
 
 A _shared package_ or library is intended to be imported by another package or application; an _application_ is a self-contained, standalone, runnable package. Unfortunately, Python’s packaging ecosystem is mostly focused on packaging shared packages (libraries), and packaging Python applications is not as well-supported ([discussion](https://discuss.python.org/t/help-packaging-optional-application-features-using-extras/14074/7)). This template, however, supports both scenarios.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ something = "package.__main__:main"
 
 [project.optional-dependencies]
 dev = [
-    "bandit >=1.7.1,<=1.7.4",
     "flake8 ==4.0.1",
     "flake8-builtins ==1.5.3",
     "flake8-docstrings ==1.6.0",


### PR DESCRIPTION
Thank you @travisjungroth for https://github.com/jenstroeger/python-package-template/pull/77#issuecomment-1152987935, this change adds [Bandit](https://github.com/PyCQA/bandit) as a git commit hook as per https://github.com/PyCQA/bandit/issues/902#issuecomment-1132322452.