### PR TITLE
ci: add a bunch of useful Flake8 plugins to git commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,7 @@ max-line-length = 120
 # Enable Bugbear's extended opinionated checks.
 # https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings
 extend-select = B9
+
+# Ensure that flake8 warnings are silenced correctly.
+# https://github.com/plinss/flake8-noqa#options
+noqa-require-code = true

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,10 @@
 # Unfortunately, flake8 does not support pyproject.toml configuration.
 # https://github.com/PyCQA/flake8/issues/234
 [flake8]
-show-source = true
+ignore =
+per-file-ignores =
 max-line-length = 120
+show-source = true
 
 # Enable Bugbear's extended opinionated checks.
 # https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings

--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,7 @@
 [flake8]
 show-source = true
 max-line-length = 120
+
+# Enable Bugbear's extended opinionated checks.
+# https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings
+extend-select = B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
   - id: flake8
     name: Check flake8 issues
     files: ^src/package/|^tests/
-    additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.2.5, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, flake8-simplify==0.18.0, pep8-naming==0.12.1]
+    additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.2.5, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, pep8-naming==0.12.1]
 
 # Run Pylint from the local repo to make sure venv packages
 # specified in pyproject.toml are available.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
   rev: 4.0.1
   hooks:
   - id: flake8
-    name: Enforce PEP8 style guide
+    name: Check flake8 issues
     files: ^src/package/|^tests/
     additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.2.5, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, flake8-simplify==0.18.0, pep8-naming==0.12.1]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
   - id: flake8
     name: Enforce PEP8 style guide
     files: ^src/package/|^tests/
-    additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, flake8-simplify==0.18.0, pep8-naming==0.12.1]
+    additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.2.5, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, flake8-simplify==0.18.0, pep8-naming==0.12.1]
 
 # Run Pylint from the local repo to make sure venv packages
 # specified in pyproject.toml are available.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
   - id: flake8
     name: Enforce PEP8 style guide
     files: ^src/package/|^tests/
-    additional_dependencies: [flake8-builtins==1.5.3, flake8-docstrings==1.6.0, flake8-rst-docstrings==0.2.3, pep8-naming==0.12.1]
+    additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, flake8-simplify==0.18.0, pep8-naming==0.12.1]
 
 # Run Pylint from the local repo to make sure venv packages
 # specified in pyproject.toml are available.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,8 @@ repos:
     files: ^src/package/|^tests/
     args: [--py39-plus]
 
-# Similar to pylint, with a few more/different checks.
+# Similar to pylint, with a few more/different checks. For more available
+# extensions: https://github.com/DmytroLitvinov/awesome-flake8-extensions
 - repo: https://github.com/pycqa/flake8
   rev: 4.0.1
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,9 @@ something = "package.__main__:main"
 
 [project.optional-dependencies]
 dev = [
-    "flake8 ==4.0.1",
-    "flake8-builtins ==1.5.3",
-    "flake8-docstrings ==1.6.0",
-    "flake8-rst-docstrings >=0.2.3,<=0.2.5",
     "flit >=3.2.0,<4",
     "hashin ==0.17.0",
     "mypy >=0.921,<=0.950",
-    "pep8-naming ==0.12.1",
     "pylint >=2.9.3,<=2.13.9",
 ]
 docs = [

--- a/src/package/something.py
+++ b/src/package/something.py
@@ -7,4 +7,4 @@ class Something:
     @staticmethod
     def do_something(value: bool = False) -> bool:
         """Return true, always."""
-        return value or True
+        return value or True  # noqa: SIM222

--- a/src/package/something.py
+++ b/src/package/something.py
@@ -7,4 +7,4 @@ class Something:
     @staticmethod
     def do_something(value: bool = False) -> bool:
         """Return true, always."""
-        return value or True  # noqa: SIM222
+        return value or True


### PR DESCRIPTION
Poking through a few other packages I came across these `flake8` plugins that I think are useful to add:
- [bugbear](https://github.com/PyCQA/flake8-bugbear)
- [comprehensions](https://github.com/adamchainz/flake8-comprehensions)
- [mutable](https://github.com/ebeweber/flake8-mutable) (somewhat dated though)
- [noqa](https://github.com/plinss/flake8-noqa)
- [pytest-style](https://github.com/m-burst/flake8-pytest-style)

We’d also consider:
- [scream](https://github.com/MartinThoma/flake8-scream)
- Review this list of [Awesome Flake8 Plugins](https://github.com/DmytroLitvinov/awesome-flake8-extensions)