### PR TITLE
fix: don’t pin Black to a particular Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
   hooks:
   - id: black
     name: Format code
+    args: [--config, pyproject.toml]
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.12.1
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ skips = ["B101"]
 # https://github.com/psf/black#configuration
 [tool.black]
 line-length = 120
-target-version = ["py39"]
 
 
 [tool.coverage.report]


### PR DESCRIPTION
We should’t pin `black` to a particular Python version because the user may run a different version than pinned. Black is capable of “auto-discovery” ([docs](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options)):

```
      -t, --target-version [py33|py34|py35|py36|py37|py38|py39|py310]
                                  Python versions that should be supported by
                                  Black's output. [default: per-file auto-
                                  detection]
```
So hopefully the auto-discovery applies to the Python version as well.