### PR TITLE
fix(ci): use dedicated RELEASE_TOKEN for Release Action job

### DIFF
--- a/.github/workflows/check-and-release-main.yaml
+++ b/.github/workflows/check-and-release-main.yaml
@@ -56,10 +56,10 @@ jobs:
       with:
         # Private repos with protected branches may need to set that token to make the Action work. For a
         # discussion of this problem, see: https://github.com/relekang/python-semantic-release/issues/311
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_TOKEN }}
         fetch-depth: 0
     - name: Python Semantic Release
       uses: relekang/python-semantic-release@595352a8fb97f219cb8362e2a13e4f59d8064aa0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.RELEASE_TOKEN }}
         pypi_token: ''  # We don't publish to PyPi: ${{ secrets.PYPI_TOKEN }}

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -216,7 +216,7 @@ open docs/_build/html/index.html
 
 To enable automation for versioning, package publishing, and changelog generation it is important to use meaningful [conventional commit messages](https://www.conventionalcommits.org/)! This package template already has a [semantic release Github Action](https://github.com/relekang/python-semantic-release) enabled which is set up to take care of all three of these aspects — every time changes are merged into the `main` branch.
 
-For more configuration options, please refer to the `tool.semantic_release` section in the `pyproject.toml` file, and read the [semantic release documentation](https://python-semantic-release.readthedocs.io/en/latest/).
+If you work with protected branches then make sure to add a `RELEASE_TOKEN` secret to your repository, see [here](https://github.com/relekang/python-semantic-release/issues/311#issuecomment-1157270026) for how to do that. For more configuration options, please refer to the `tool.semantic_release` section in the `pyproject.toml` file, and read the [semantic release documentation](https://python-semantic-release.readthedocs.io/en/latest/).
 
 You can also install and run the tool manually and locally, for example:
 


### PR DESCRIPTION
Note that this fix merges directly into the `main` branch to address [this Release Action failure](https://github.com/jenstroeger/python-package-template/runs/6647674368?check_suite_focus=true). For more discussion on the problem and how to resolve it, see https://github.com/relekang/python-semantic-release/issues/311#issuecomment-1157270026.

TBH, I’m tempted to amend this change to commit https://github.com/jenstroeger/python-package-template/commit/5c8a47f13c26d727fea022a33b8c3baf87f7bbcd (the breaking change at the current HEAD of `main`).