### PR TITLE
fix: bump min pytest version according to the "test" dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,9 +140,9 @@ max-line-length = 120
 max-module-lines = 1000
 
 
-# https://docs.pytest.org/en/6.2.x/customize.html#configuration-file-formats
-# https://docs.pytest.org/en/6.2.x/reference.html#configuration-options
-# https://docs.pytest.org/en/6.2.x/reference.html#command-line-flags
+# https://docs.pytest.org/en/latest/reference/customize.html#configuration-file-formats
+# https://docs.pytest.org/en/latest/reference/reference.html#configuration-options
+# https://docs.pytest.org/en/latest/reference/reference.html#command-line-flags
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "--verbose --doctest-modules -ra --cov package"  # Consider adding --pdb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ max-module-lines = 1000
 # https://docs.pytest.org/en/6.2.x/reference.html#configuration-options
 # https://docs.pytest.org/en/6.2.x/reference.html#command-line-flags
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 addopts = "--verbose --doctest-modules -ra --cov package"  # Consider adding --pdb
 doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [


### PR DESCRIPTION
Refs: d7956486a9d8d7a5292433a34fe88e0c319011dc