### PR TITLE
chore: remove duplicate pylint settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ disable = [
     "too-many-arguments",
     "too-many-branches",
     "too-many-instance-attributes",
+    "too-many-lines",
     "too-many-locals",
     "too-many-nested-blocks",
     "too-many-return-statements",
@@ -137,7 +138,6 @@ notes = [
 
 [tool.pylint.FORMAT]
 max-line-length = 120
-max-module-lines = 1000
 
 
 # https://docs.pytest.org/en/6.2.x/customize.html#configuration-file-formats


### PR DESCRIPTION
Remove the [`max-module-lines`](https://pylint.pycqa.org/en/1.9/technical_reference/features.html#id8) setting because it defaults to 1000 anyway, and add a missing [`too-many-lines`](https://pylint.pycqa.org/en/1.9/technical_reference/features.html#id9) which overrides the max lines anyway.