### PR TITLE
feat: add Action to generate Github Wiki pages from documentation upon releases

### DIFF
--- a/.github/workflows/wiki-documentation.yaml
+++ b/.github/workflows/wiki-documentation.yaml
@@ -1,8 +1,8 @@
 # This workflow publishes Markdown docs to Github Wiki.
 # Some manual setup is required before using it:
 #   1. Enable Wiki in repository and create at least one page.
-#   2. Generate a Personal Access Token (PAT) with "repo" scope enabled.
-#   3. Add the generated PAT as a secret named "GH_PERSONAL_ACCESS_TOKEN".
+#   2. Make sure there's a Personal Access Token (PAT) with "repo" scope enabled.
+#   3. Add the generated PAT as a secret named "REPO_ACCESS_TOKEN".
 # For details, see https://github.com/marketplace/actions/publish-to-github-wiki#setup
 name: Generate Wiki Pages
 
@@ -37,4 +37,4 @@ jobs:
       with:
         path: docs/_build/markdown
       env:
-        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/wiki-documentation.yaml
+++ b/.github/workflows/wiki-documentation.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -29,7 +29,7 @@ jobs:
         make docs-md
         mv docs/_build/markdown/index.md docs/_build/markdown/Home.md
     - name: Push to Wiki
-      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      uses: SwiftDocOrg/github-wiki-publish-action@a87db85ed06e4431be29cfdcb22b9653881305d0
       with:
         path: docs/_build/markdown
       env:

--- a/.github/workflows/wiki-documentation.yaml
+++ b/.github/workflows/wiki-documentation.yaml
@@ -25,7 +25,9 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install dependencies
-      run: make setup
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade --upgrade-strategy eager --editable .[docs]
       env:
         PYTHON: python
     - name: Generate Markdown docs

--- a/.github/workflows/wiki-documentation.yaml
+++ b/.github/workflows/wiki-documentation.yaml
@@ -14,6 +14,10 @@ jobs:
   generate-wiki:
     runs-on: ubuntu-latest
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - name: Set up Python

--- a/.github/workflows/wiki-documentation.yaml
+++ b/.github/workflows/wiki-documentation.yaml
@@ -1,0 +1,36 @@
+# This workflow publishes Markdown docs to Github Wiki.
+# Some manual setup is required before using it:
+#   1. Enable Wiki in repository and create at least one page.
+#   2. Generate a Personal Access Token (PAT) with "repo" scope enabled.
+#   3. Add the generated PAT as a secret named "GH_PERSONAL_ACCESS_TOKEN".
+# For details, see https://github.com/marketplace/actions/publish-to-github-wiki#setup
+name: Generate Wiki Pages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate-wiki:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: make setup
+      env:
+        PYTHON: python
+    - name: Generate Markdown docs
+      run: |
+        make docs-md
+        mv docs/_build/markdown/index.md docs/_build/markdown/Home.md
+    - name: Push to Wiki
+      uses: SwiftDocOrg/github-wiki-publish-action@v1
+      with:
+        path: docs/_build/markdown
+      env:
+        GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,20 @@ dist/package-$(PACKAGE_VERSION)-docs-html.zip: docs
 	python -m zipfile -c dist/package-$(PACKAGE_VERSION)-docs-html.zip docs/_build/html
 
 # Build the HTML documentation from the package's source.
-.PHONY: docs
-docs: docs/_build/html/index.html
+.PHONY: docs-html
+docs-html: docs/_build/html/index.html
 docs/_build/html/index.html: check test
 	$(MAKE) -C docs/ html
+
+# Build the Markdown documentation from the package's source.
+.PHONY: docs-md
+docs-md: docs/_build/markdown/index.md
+docs/_build/markdown/index.md: check test
+	$(MAKE) -C docs/ markdown
+
+# Build both HTML and Markdown documentation from the package's source.
+.PHONY: docs
+docs: docs-html docs-md
 
 # Clean test caches and remove build artifacts.
 .PHONY: dist-clean clean

--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ dist/package-$(PACKAGE_VERSION)-docs-html.zip: docs
 # Build the HTML documentation from the package's source.
 .PHONY: docs-html
 docs-html: docs/_build/html/index.html
-docs/_build/html/index.html: check test
+docs/_build/html/index.html:
 	$(MAKE) -C docs/ html
 
 # Build the Markdown documentation from the package's source.
 .PHONY: docs-md
 docs-md: docs/_build/markdown/index.md
-docs/_build/markdown/index.md: check test
+docs/_build/markdown/index.md:
 	$(MAKE) -C docs/ markdown
 
 # Build both HTML and Markdown documentation from the package's source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 ]
 docs = [
     "sphinx >=4.1.2,<=4.5.0",
-    "sphinxnotes-markdown-builder>=0.5.6,<1.0.0",
+    "sphinxnotes-markdown-builder >=0.5.6,<1.0.0",
 ]
 hooks = [
     "pre-commit >=2.13.0,<=2.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
 ]
 docs = [
     "sphinx >=4.1.2,<=4.5.0",
+    "sphinxnotes-markdown-builder>=0.5.6,<1.0.0",
 ]
 hooks = [
     "pre-commit >=2.13.0,<=2.19.1",


### PR DESCRIPTION
Note that after this change, there are new `make` targets for generating documentation:

```
$ make docs-html    # generates HTML in docs/_build/html
$ make docs-md      # generates Markdown in docs/_build/markdown
$ make docs         # generates both HTML & Markdown
```