### PR TITLE
feat: consolidate sdist and wheel into a single build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ NEED_VENV := $(or \
   $(findstring check,$(MAKECMDGOALS)), \
   $(findstring test,$(MAKECMDGOALS)), \
   $(findstring dist,$(MAKECMDGOALS)), \
-  $(findstring bdist-wheel,$(MAKECMDGOALS)), \
+  $(findstring wheel,$(MAKECMDGOALS)), \
   $(findstring sdist,$(MAKECMDGOALS)), \
   $(findstring docs,$(MAKECMDGOALS)) \
 )

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@ NEED_VENV := $(or \
   $(findstring check,$(MAKECMDGOALS)), \
   $(findstring test,$(MAKECMDGOALS)), \
   $(findstring dist,$(MAKECMDGOALS)), \
-  $(findstring wheel,$(MAKECMDGOALS)), \
-  $(findstring sdist,$(MAKECMDGOALS)), \
   $(findstring docs,$(MAKECMDGOALS)) \
 )
 ifeq ($(NEED_VENV),)
@@ -91,17 +89,15 @@ test:
 	pre-commit run pytest --hook-stage push
 
 # Build a source distribution package and a binary wheel distribution artifact.
-.PHONY: dist wheel sdist
+.PHONY: dist
 ifeq ($(wildcard .upgraded),)
   PACKAGE_VERSION=unknown
 else
   PACKAGE_VERSION=$(shell python -c 'import package; print(package.__version__)')
 endif
-dist: wheel sdist
-wheel: dist/package-$(PACKAGE_VERSION)-py3-none-any.whl
+dist: dist/package-$(PACKAGE_VERSION)-py3-none-any.whl dist/package-$(PACKAGE_VERSION).tar.gz
 dist/package-$(PACKAGE_VERSION)-py3-none-any.whl: check test
 	flit build --setup-py --format wheel
-sdist: dist/package-$(PACKAGE_VERSION).tar.gz
 dist/package-$(PACKAGE_VERSION).tar.gz: check test
 	flit build --setup-py --format sdist
 


### PR DESCRIPTION
Which also raises the question: do we want to handle the source and binary distribution separately? Now that we switched to `flit` as a build core (see PR https://github.com/jenstroeger/python-package-template/pull/208), we could just use [`flit build`](https://flit.pypa.io/en/latest/cmdline.html#flit-build) to build both…