### PR TITLE
chore: add settings path to isort in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
   hooks:
   - id: isort
     name: Sort import statements
+    args: [--settings-path, pyproject.toml]
 
 # Add Black code formatters.
 - repo: https://github.com/ambv/black


### PR DESCRIPTION
This leaves only pytest and commitizen without an explicitly set configuration file:

- pytest offers a [`-c` option (no long-option equivalent)](https://docs.pytest.org/en/latest/reference/customize.html#finding-the-rootdir) from where to load a configuration file, but seems quite explicit about determining its own root dir (and config file) automatically; and
- commitizen doesn’t provide a way to configure it ([docs](https://github.com/commitizen-tools/commitizen#help), [code](https://github.com/commitizen-tools/commitizen/blob/afa0d93544405bb0a871b5072e0a814720d933be/commitizen/cli.py#L27-L39)).

So we’re good with providing explicit configurations? 🤓