### PR TITLE
feat!: replace the Makefile’s quick-check goal with check-code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,15 @@ requirements.txt: pyproject.toml
 all: check test dist docs
 
 # Run some or all checks over the package code base.
-.PHONY: quick-check check
-quick-check:
+.PHONY: check check-code check-bandit check-flake8 check-lint check-mypy
+check-code: check-bandit check-flake8 check-lint check-mypy
+check-bandit:
+	pre-commit run bandit --all-files
+check-flake8:
+	pre-commit run flake8 --all-files
+check-lint:
 	pre-commit run pylint --all-files
+check-mypy:
 	pre-commit run mypy --all-files
 check:
 	pre-commit run --all-files

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -143,16 +143,16 @@ Using the pre-commit tool and its `.pre-commit-config.yaml` configuration, the f
 You can also run these hooks manually, which comes in very handy during daily development tasks. For example
 
 ```bash
-make quick-check
+make check-code
 ```
 
-runs `pylint` and `mypy` only, whereas
+runs all the code checks (i.e. `bandit`, `flake8`, `pylint` and `mypy`), whereas
 
 ```bash
 make check
 ```
 
-runs _all_ installed git hooks over your code.
+runs _all_ installed git hooks over your code. For more control over the code checks, the Makefile also implements the `check-bandit`, `check-flake8`, `check-lint`, and `check-mypy` goals.
 
 ## Testing
 


### PR DESCRIPTION
A few new goals which, I think, make daily developer life a little easier.

If we consider the Makefile as an interface of this repo (which it kinda is) then this is a breaking change 🤔