### PR TITLE
feat: add pytest-env and pytest-custom-exit-code plugin support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ docs = [
 hooks = [
     "pre-commit >=2.13.0,<=2.19.1",
 ]
-# Note that the `custom_exit_code` and `env` plugins maybe currently be unmaintained.
+# Note that the `custom_exit_code` and `env` plugins may currently be unmaintained.
 test = [
     "hypothesis >=6.21.0,<=6.46.9",
     "pytest >=7.1.2,<8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ docs = [
 hooks = [
     "pre-commit >=2.13.0,<=2.19.1",
 ]
+# Note that the `custom_exit_code` and `env` plugins maybe currently be unmaintained.
 test = [
     "hypothesis >=6.21.0,<=6.46.9",
     "pytest >=7.1.2,<8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ hooks = [
 test = [
     "hypothesis >=6.21.0,<=6.46.9",
     "pytest >=7.1.2,<8.0.0",
+    "pytest-custom_exit_code ==0.3.0",
     "pytest-cov ==3.0.0",
+    "pytest-env ==0.6.2",
 ]
 
 [project.urls]
@@ -158,6 +160,7 @@ doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [
     "tests",
 ]
+env = []
 
 
 # https://python-semantic-release.readthedocs.io/en/latest/


### PR DESCRIPTION
The two plugins, I think, are generally useful in a CI/CD development & test environment:

- https://github.com/MobileDynasty/pytest-env
- https://github.com/yashtodi94/pytest-custom_exit_code

Unfortunately both are somewhat dated…