### PR TITLE
fix: flit doesn’t support MANIFEST.in, fix sdist accordingly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,13 +142,6 @@ repos:
   # - id: pretty-format-toml
   #   args: [--autofix]
 
-# Make sure that the package's MANIFEST.in file works.
-- repo: https://github.com/mgedmin/check-manifest
-  rev: '0.48'
-  hooks:
-  - id: check-manifest
-    name: Check package manifest
-
 # On push to the remote, run the unit tests.
 - repo: local
   hooks:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-recursive-include src/package *
-recursive-exclude src/package/**/__pycache__ *
-
-exclude .gitignore .pre-commit-config.yaml .flake8
-exclude CHANGELOG.md SECURITY.md MANIFEST.in UPSTREAM_README.md UPSTREAM_CHANGELOG.md UPSTREAM_SECURITY.md Makefile
-exclude commitlint.rules.js pyproject.toml
-recursive-exclude .github *
-recursive-exclude docs *
-recursive-exclude tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ exclude = [
     "CHANGELOG.md",
     "Makefile",
     "SECURITY.md",
-    "UPSTREAM_*.md",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,24 @@ omit = [
 ]
 
 
+# https://flit.pypa.io/en/latest/pyproject_toml.html#sdist-section
+# See also: https://github.com/pypa/flit/issues/565
+[tool.flit.sdist]
+include = []
+exclude = [
+    ".github/",
+    "docs/",
+    "tests/",
+    ".flake8",
+    ".gitignore",
+    ".pre-commit-config.yaml",
+    "CHANGELOG.md",
+    "Makefile",
+    "SECURITY.md",
+    "UPSTREAM_*.md",
+]
+
+
 # https://pycqa.github.io/isort/
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Following up on our Slack conversation and issue https://github.com/pypa/flit/issues/565, this change fixes `flit`’s source distribution.

Interestingly installing the `.tar.gz` sdist file fails:
```
> pip install /path/to/template/dist/package-1.6.1.tar.gz 
Processing /path/to/template/dist/package-1.6.1.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [29 lines of output]
      Traceback (most recent call last):
        File "/.../T/pip-build-env-n3xxqt2l/overlay/lib/python3.9/site-packages/flit_core/config.py", line 273, in description_from_file
          with desc_path.open('r', encoding='utf-8') as f:
        File "/.../3.9/lib/python3.9/pathlib.py", line 1252, in open
          return io.open(self, mode, buffering, encoding, errors, newline,
        File "/.../3.9/lib/python3.9/pathlib.py", line 1120, in _opener
          return self._accessor.open(self, flags, mode)
      FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
```
because the `README.md` is a symlink to the actual `UPSTREAM_README.md`. I think we should consider getting rid of that… (PR https://github.com/jenstroeger/python-package-template/pull/245)