### PR TITLE
chore: add file types to some code checking hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
   - id: flake8
     name: Check flake8 issues
     files: ^src/package/|^tests/
+    types: [text, python]
     additional_dependencies: [flake8-bugbear==22.4.25, flake8-builtins==1.5.3, flake8-comprehensions==3.10.0, flake8-docstrings==1.6.0, flake8-mutable==1.2.0, flake8-noqa==1.2.5, flake8-pytest-style==1.6.0, flake8-rst-docstrings==0.2.3, pep8-naming==0.12.1]
 
 # Run Pylint from the local repo to make sure venv packages
@@ -69,6 +70,7 @@ repos:
     entry: pylint
     language: python
     files: ^src/package/|^tests/
+    types: [text, python]
     args: [--rcfile, pyproject.toml]
 
 # Type-check all Python code.
@@ -79,6 +81,7 @@ repos:
     entry: mypy
     language: python
     files: ^src/package/|^tests/
+    types: [text, python]
     args: [--config-file, pyproject.toml]
 
 # Check for potential security issues.
@@ -89,6 +92,7 @@ repos:
     name: Check for security issues
     args: [--configfile, pyproject.toml]
     files: ^src/package/|^tests/
+    types: [text, python]
     additional_dependencies: ['bandit[toml]']
 
 # Enable a whole bunch of useful helper hooks, too.


### PR DESCRIPTION
If the `src/package/` folder contains files other than Python, some of the code checkers complain. So, this change constrains the files passed to the hook to Python files only.

The [documentation](https://pre-commit.com/#filtering-files-with-types) suggests
```yaml
    types: [file, python]
```
though.