### PR TITLE
fix: when nuking code and test caches, also nuke pre-commit hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ clean: dist-clean
 # Remove code caches, or the entire virtual environment.
 .PHONY: nuke-caches nuke
 nuke-caches: clean
+	pre-commit clean
 	find src/ -name __pycache__ -exec rm -fr {} +
 	find tests/ -name __pycache__ -exec rm -fr {} +
 nuke: nuke-caches


### PR DESCRIPTION
From the [pre-commit docs](https://pre-commit.com/#pre-commit-clean):

> **pre-commit clean [options]**
> 
> Clean out cached pre-commit files.
> 
> Options: (no additional options)

So I thought that this would be useful when calling `make nuke-caches`.