### PR TITLE
fix: default goal for make should be to build the entire package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ ifeq ($(shell test pyproject.toml -nt .venv/upgraded-on; echo $$?),0)
   $(warning If this is not correct then run `make upgrade-quiet`)
 endif
 
+# Check, test, and build artifacts for this package.
+.PHONY: all
+all: check test dist docs
+
 # Create a virtual environment, either for Python3.10 (default) or using
 # the Python interpreter specified in the PYTHON environment variable.
 .PHONY: venv
@@ -85,10 +89,6 @@ requirements.txt: pyproject.toml
 	echo "" > requirements.txt
 	# See also: https://github.com/peterbe/hashin/issues/139
 	for pkg in `python -m pip list --format freeze`; do hashin --verbose $$pkg; done
-
-# Check, test, and build artifacts for this package.
-.PHONY: all
-all: check test dist docs
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy


### PR DESCRIPTION
Calling `make` without any arguments makes the first goal in the Makefile because we did not specify a [`.DEFAULT`](https://www.gnu.org/software/make/manual/html_node/Special-Targets.html). That currently is the `venv` goal to install the Python virtual environment.

I think it makes<sup>*</sup> more sense (and is [common](https://stackoverflow.com/questions/27242905/makefile-all-vs-default-targets)) to make `all` that default goal such that running just `make` makes the entire package.

This change hoists `all` up to be the first goal in the Makefile.

—————
<sup>*</sup> Pun intended.