### PR TITLE
feat: always create a reproducible build with `make dist`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,11 +106,12 @@ jobs:
         WHEEL_PATH=$(find dist -name "*.whl")
         SBOM_PATH=$(find dist -name "*-sbom.json")
         HTML_DOCS_PATH=$(find dist -name *-docs-html.zip)
+        BUILD_EPOCH_PATH=$(find dist -name *-build-epoch.txt)
         # Make sure dist/RELEASE_NOTES.md (which contains the release notes) exists.
         touch dist/RELEASE_NOTES.md
         NOTES_PATH=$(find dist -name RELEASE_NOTES.md)
         # Compute the sha digest for all the release files and encode them using base64.
-        DIGEST=$(sha256sum $TARBALL_PATH $WHEEL_PATH $SBOM_PATH $HTML_DOCS_PATH $NOTES_PATH | base64 -w0)
+        DIGEST=$(sha256sum $TARBALL_PATH $WHEEL_PATH $SBOM_PATH $HTML_DOCS_PATH $BUILD_EPOCH_PATH $NOTES_PATH | base64 -w0)
         echo "Digest of artifacts is $DIGEST."
         # Set the computed sha digest as the output of this job.
         echo "::set-output name=artifacts-sha256::$DIGEST"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The build process in this repository follows the requirements in the [SLSA frame
 - Source dist (tarball)
 - SBOM (CycloneDx format)
 - HTML Docs
+- A [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time) timestamp file of the build time for [reproducible builds](https://flit.pypa.io/en/latest/reproducible.html)
 
 To verify the artifact using the provenance follow the instructions in the [SLSA verifier](https://github.com/slsa-framework/slsa-verifier) project to install the verifier tool. After downloading the artifacts and provenance, verify each artifact individually, e.g.,:
 


### PR DESCRIPTION
This actually works 🤓 First, we build the assets:
```
> make dist
flit build --setup-py --format wheel
flit build --setup-py --format sdist
python -m zipfile -c dist/package-2.2.0-docs-html.zip docs/_build/html
echo 1659672848 > dist/package-2.2.0-build-epoch.txt
```
and check the wheel’s hash so we can compare it later:
```
> md5sum dist/package-2.2.0-py3-none-any.whl
081aaf0482704b78950854690c8b30d7  dist/package-2.2.0-py3-none-any.whl
```
Then touch a source file so it has a different time stamp but the same content:
```
> touch src/package/something.py
```
Next, build the package _again_ but this time using the time stamp from the previous build:
```
> SOURCE_DATE_EPOCH=1659672848 make dist
flit build --setup-py --format wheel
Zip timestamps will be from SOURCE_DATE_EPOCH: 2022-08-05 04:14:08                                  I-flit_core.wheel
flit build --setup-py --format sdist
python -m zipfile -c dist/package-2.2.0-docs-html.zip docs/_build/html
echo 1659672848 > dist/package-2.2.0-build-epoch.txt
```
And check the generated package again to make sure it’s the exact same file:
```
 > md5sum dist/package-2.2.0-py3-none-any.whl
081aaf0482704b78950854690c8b30d7  dist/package-2.2.0-py3-none-any.whl
```
Without the explicit time stamp we’d get a _different_ file:
```
> make dist
...
> md5sum dist/package-2.2.0-py3-none-any.whl
1468cc41b97ae0a43a5e5fbd8e204127  dist/package-2.2.0-py3-none-any.whl
```