### PR TITLE
fix: disable noise when freezing the current venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,14 +95,16 @@ upgrade-quiet:
 sbom: requirements
 	cyclonedx-bom --force --requirements --format json --output dist/package-$(PACKAGE_VERSION)-sbom.json
 
-# Generate a requirements.txt file containing version and integrity
-# hashes for all packages currently installed in the virtual environment.
+# Generate a requirements.txt file containing version and integrity hashes for all
+# packages currently installed in the virtual environment. There's no easy way to
+# do this, and we have to use yet another external package. For more discussion, see
+# https://github.com/pypa/pip/issues/4732
+# https://github.com/peterbe/hashin/issues/139
 .PHONY: requirements
 requirements: requirements.txt
 requirements.txt: pyproject.toml
 	echo "" > requirements.txt
-	# See also: https://github.com/peterbe/hashin/issues/139
-	for pkg in `python -m pip list --format freeze`; do hashin --verbose $$pkg; done
+	for pkg in `python -m pip list --format freeze --disable-pip-version-check`; do hashin --verbose $$pkg; done
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy


### PR DESCRIPTION
Following up on our conversation about failing `hashin` calls: the failure is legit. By default, [`pip list`](https://pip.pypa.io/en/stable/cli/pip_list/) makes additional noise:
```
> pip list --format freeze 
alabaster==0.7.12
...
zipp==3.8.1

[notice] A new release of pip available: 22.1.2 -> 22.2.2
[notice] To update, run: pip install --upgrade pip
```
which `hashin` interprets as packages and attempts to generate hashes for. That doesn’t work out well, of course<sup>*</sup> 🤦🏻‍♂️ 
```
zipp==3.8.1 \
    --hash=sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2 \
    --hash=sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009
a==1.0 \
    --hash=sha256:ac14dc3a69f5746f06fd72fd2f2dace84bc07247182b3b117eaaa14dfd5fb0cd
of==1.0.1 \
    --hash=sha256:d4beff74d8207396e3938def59b9d9361ffb8055fab237e6666c7df4b8434b21 \
    --hash=sha256:f4efcf482d508fa71bf6445a1036e31823e097be66f831b2c4f05173b76127c8
to==0.3 \
    --hash=sha256:b51c951a04f0f7fa45cd99a871e0897e6a461e510b21860f145b95465544e51b
install==1.3.5 \
    --hash=sha256:0d3fadf4aa62c95efe8d34757c8507eb46177f86c016c21c6551eafc6a53d5a9 \
    --hash=sha256:e67c8a0be5ccf8cb4ffa17d090f3a61b6e820e6a7e21cd1d2c0f7bc59b18e647
```

Adding the [`--disable-pip-version-check`](https://pip.pypa.io/en/stable/cli/pip/#cmdoption-disable-pip-version-check) cmd line option disables these last three lines, but I think there’s still a chance of other output here.

Also see linked issue https://github.com/pypa/pip/issues/4732

—————
<sup>*</sup> What a nice gateway for malicious packages this is…