### PR TITLE
ci: build requirements.txt and SBOM artifacts only on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,15 +92,16 @@ jobs:
       # those targets first and only builds the package if they succeed.
       run: |
         # Build the sdist and wheel distribution of the package and docs as a zip file.
-        # Generate the requirements.txt that contains the hash digests of the dependencies.
-        # Generate the SBOM using CyclonDX SBOM generator.
-        make dist requirements sbom
+        make dist
     - name: Compute package hash
       if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
       id: compute-hash
       shell: bash
       run: |
         set -euo pipefail
+        # Generate the requirements.txt that contains the hash digests of the dependencies and
+        # generate the SBOM using CyclonDX SBOM generator.
+        make requirements sbom
         # Find the paths to the files that will be included in the release.
         TARBALL_PATH=$(find dist -name "*.tar.gz")
         WHEEL_PATH=$(find dist -name "*.whl")


### PR DESCRIPTION
It’s probably enough to build the `requirements.txt` file and the SBOM only when we create a release…

@behnazh we currently build and upload the release artifacts with _every run_ of the workflow, and only the “Update release tag” step is guarded

https://github.com/jenstroeger/python-package-template/blob/c7541754294c634cd807068ffaf37bd0279cbb52/.github/workflows/build.yaml#L124

Should we limit the other steps too?