### PR TITLE
docs: fix typo in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository is intended to be a base template, a cookiecutter for a new Pyth
 [Testing](#testing)  
 [Generating documentation](#generating-documentation)  
 [Versioning, publishing and changelog](#versioning-publishing-and-changelog)  
-[Build integrity using SLSA framework](#build-integrity-using-slsa-framework)
+[Build integrity using SLSA framework](#build-integrity-using-slsa-framework)  
 [Cleaning up](#cleaning-up)  
 [Frequently asked questions](#frequently-asked-questions)  
 


### PR DESCRIPTION
The two spaces are necessary to add the line break, or else the TOC entry is on the same line as its predecessor—see the TOC in the [current README](https://github.com/jenstroeger/python-package-template/blob/c7541754294c634cd807068ffaf37bd0279cbb52/README.md).