### PR TITLE
chore: add reviewers to the Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,9 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: staging
+  reviewers:
+  - jenstroeger
+  - behnazh
 
 - package-ecosystem: github-actions
   directory: /
@@ -25,3 +28,6 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: staging
+  reviewers:
+  - jenstroeger
+  - behnazh

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,9 +14,9 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: staging
-  reviewers:
-  - jenstroeger
-  - behnazh
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
+  # reviewers:
+  # -
 
 - package-ecosystem: github-actions
   directory: /
@@ -28,6 +28,6 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: staging
-  reviewers:
-  - jenstroeger
-  - behnazh
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
+  # reviewers:
+  # -


### PR DESCRIPTION
We can assign one or more reviewers to PRs that Dependabot opens ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers)), and perhaps it’s worthwhile adding to the configuration? Not sure if we want to comment that out or leave it as an active feature.

We we add this change, we probably should document it in our README.