### PR TITLE
chore: use actual .venv directory name in nuke-caches Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,6 @@ nuke: nuke-caches
 	if [ ! -z "${VIRTUAL_ENV}" ]; then \
 	  echo "Deactivating and nuking virtual environment!"; \
 	  deactivate; \
-	  rm -fr $(VIRTUAL_ENV); \
+	  rm -fr .venv; \
 	fi
 	rm -f requirements.txt


### PR DESCRIPTION
This is to be consistent with the remainder of the Makefile where we’ve established the convention that the Python virtual environment is the `.venv/` folder. The `VIRTUAL_ENV` environment variable, in contrast, is used only to check whether a virtual env was _activated_ but not to determine its location.