### PR TITLE
fix(ci): allow PR Action to check commits across branches of forks

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -45,10 +45,14 @@ jobs:
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
     - name: Check PR commit messages
-      run: cz check --rev-range origin/$PR_BASE_BRANCH_NAME..origin/$PR_HEAD_BRANCH_NAME
+      run: |
+        git remote add other $PR_HEAD_REPO_CLONE_URL
+        git fetch other
+        cz check --rev-range origin/$PR_BASE_REF..other/$PR_HEAD_REF
       env:
-        PR_BASE_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
-        PR_HEAD_BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_REPO_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
 
   build:
     needs: conventional-commits


### PR DESCRIPTION
Following up on comment https://github.com/jenstroeger/python-package-template/pull/224#issuecomment-1217361225, this change provides a fix.

I tested it in a private repo against a PR in that same private repo, but wasn’t able to test it for a fork because that fork was private and belonged to another org (because I can’t fork my own repos). I think we’ll have to test this across forked public repositories for now.