### PR TITLE
chore(ci): use a runner’s global Python install instead of venv

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -46,15 +46,12 @@ jobs:
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
       with:
         python-version: ${{ matrix.python }}
-    - name: Create and activate virtual environment
-      run: |
-        make venv
-        source .venv/bin/activate
-      env:
-        PYTHON: python
-
+    # For more details see the comment in build.yaml.
+    - name: Create empty virtual environment for Actions
+      run: mkdir .venv
     - name: Install dependencies
       run: make setup
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@c0982d28099e3cb8fd8b37cfd6c2cdfea4531853


### PR DESCRIPTION
Refs: 3ad877bd49a323eae3b84a0f89a5412014c034c9

Related PR https://github.com/jenstroeger/python-package-template/pull/275.