### PR TITLE
chore: show traceback if mypy boinks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
     language: python
     files: ^src/package/|^tests/
     types: [text, python]
-    args: [--config-file, pyproject.toml]
+    args: [--show-traceback, --config-file, pyproject.toml]
 
 # Check for potential security issues.
 - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
This comes in handy if `mypy` crashes.