### PR TITLE
fix: remove requirements.txt when cleaning the distribution artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ prune:
 .PHONY: dist-clean clean
 dist-clean:
 	rm -fr dist/*
+	rm -f requirements.txt
 clean: dist-clean
 	rm -fr .coverage .hypothesis/ .mypy_cache/ .pytest_cache/
 	rm -fr docs/_build/
@@ -208,4 +209,3 @@ nuke: nuke-caches
 	  deactivate; \
 	  rm -fr .venv; \
 	fi
-	rm -f requirements.txt


### PR DESCRIPTION
We use the `requirements.txt` file as a distribution artifact, so we should delete it as part of the distribution too. Methinks.