### PR TITLE
chore(test): enable PYTHONWARNINGS when running pytest alone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,4 +201,6 @@ doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [
     "tests",
 ]
-env = []
+env = [
+    "PYTHONWARNINGS=always::DeprecationWarning",
+]


### PR DESCRIPTION
We already do that when running `pytest` through the git hooks:

https://github.com/jenstroeger/python-package-template/blob/f41b0e6a46061081370253b9ac17a1b62b5c85dc/.pre-commit-config.yaml#L156