### PR TITLE
chore(ci): add Harden Runner when running the PR Action workflow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,6 +22,10 @@ jobs:
     name: Check PR title and commit messages
     runs-on: ubuntu-latest
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
     - name: Check out repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:


### PR DESCRIPTION
I don’t remember: did we intentionally _not_ call the [Harden Runner](https://github.com/step-security/harden-runner) Action here?