### PR TITLE
chore(ci): reformat and split up steps to improve debugging & readability

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,4 +1,3 @@
-name: CodeQL config
-
+name: CodeQL configuration
 paths:
 - src/package

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,7 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: staging
+  # Add additional reviewers for PRs opened by Dependabot. For more information, see:
   # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
   # reviewers:
   # -
@@ -28,6 +29,7 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: staging
+  # Add additional reviewers for PRs opened by Dependabot. For more information, see:
   # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
   # reviewers:
   # -

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,23 @@
 # This is a trusted builder implemented as a reusable workflow that can be called by other
 # Actions workflows. It checks, tests, and builds the artifacts including SBOM and documentations,
-# and computes hash digests as output to be used by a SLSA provenance generator. The artifacts are always uploaded
-# for every job to be used for debugging purposes, but they will be removed within the specified retention days.
-# Even though we run the build in a matrix to check against different platforms, due to a known limitation of
-# reusable workflows that do not support setting strategy property from the caller workflow, we
-# only generate artifacts for ubuntu-latest and Python 3.10, which can be used to create a release.
-# See: https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations.
+# and computes hash digests as output to be used by a SLSA provenance generator. The artifacts are
+# always uploaded for every job to be used for debugging purposes, but they will be removed within
+# the specified retention days.
+#
+# Even though we run the build in a matrix to check against different platforms, due to a known
+# limitation of reusable workflows that do not support setting strategy property from the caller
+# workflow, we only generate artifacts for ubuntu-latest and Python 3.10, which can be used to
+# create a release. For details see:
+#
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
+#
+# Note: if the build workflow needs to access secrets, they need to be passed by the caller using
+# `secrets: inherit`. See also
+#
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows
+# https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+#
+# for the security recommendations.
 
 name: Build the package
 on:
@@ -34,18 +46,22 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.9', '3.10']
     steps:
+
     - name: Harden Runner
       uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Check out repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         fetch-depth: 0
+
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
       with:
         python-version: ${{ matrix.python }}
+
     # Using the Makefile assumes an activated virtual environment, which doesn't exist
     # when running in an Action environment (https://github.com/actions/setup-python/issues/359).
     # Instead we create an empty .venv folder so that the Makefile continues to function
@@ -55,39 +71,50 @@ jobs:
       run: mkdir .venv
     - name: Install dependencies
       run: make setup
-    - name: Build the package
-      # We don't need to check and test the package separately because `make dist` runs
-      # those targets first and only builds the package if they succeed.
-      # Build the sdist and wheel distribution of the package and docs as a zip file.
-      run: make dist
+
     # Audit all currently installed packages for security vulnerabilities.
     - name: Audit installed packages
       run: make audit
+
+    # Build the sdist and wheel distribution of the package and docs as a zip file.
+    # We don't need to check and test the package separately because `make dist` runs
+    # those targets first and only builds the package if they succeed.
+    - name: Build the package
+      run: make dist
+
+    # Generate the requirements.txt that contains the hash digests of the dependencies and
+    # generate the SBOM using CyclonDX SBOM generator.
+    - name: Generate requirements.txt and SBOM
+      if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
+      run: make requirements sbom
+
+    # Remove the old requirements.txt file (which includes _all_ packages) and generate a
+    # new one for the package and its actual and required dependencies only.
+    - name: Prune packages and generate required requirements.txt
+      if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
+      run: |
+        rm requirements.txt
+        make prune requirements
+
+    # Find the paths to the artifact files that will be included in the release, compute
+    # the SHA digest for all the release files and encode them using Base64, and export it
+    # from this job.
     - name: Compute package hash
       if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
       id: compute-hash
       shell: bash
       run: |
         set -euo pipefail
-        # Generate the requirements.txt that contains the hash digests of the dependencies and
-        # generate the SBOM using CyclonDX SBOM generator.
-        make requirements sbom
-        # Remove the old requirements.txt file (which includes _all_ packages) and generate a
-        # new one for the package and its actual and required dependencies only.
-        rm requirements.txt
-        make prune requirements
-        # Find the paths to the files that will be included in the release.
         TARBALL_PATH=$(find dist -name "*.tar.gz")
         WHEEL_PATH=$(find dist -name "*.whl")
         REQUIREMENTS_PATH=$(find dist -name "*-requirements.txt")
         SBOM_PATH=$(find dist -name "*-sbom.json")
-        HTML_DOCS_PATH=$(find dist -name *-docs-html.zip)
-        BUILD_EPOCH_PATH=$(find dist -name *-build-epoch.txt)
-        # Compute the sha digest for all the release files and encode them using base64.
+        HTML_DOCS_PATH=$(find dist -name "*-docs-html.zip")
+        BUILD_EPOCH_PATH=$(find dist -name "*-build-epoch.txt")
         DIGEST=$(sha256sum $TARBALL_PATH $WHEEL_PATH $REQUIREMENTS_PATH $SBOM_PATH $HTML_DOCS_PATH $BUILD_EPOCH_PATH | base64 -w0)
         echo "Digest of artifacts is $DIGEST."
-        # Set the computed sha digest as the output of this job.
         echo "::set-output name=artifacts-sha256::$DIGEST"
+
     # For now only generate artifacts for the specified OS and Python version in env variables.
     # Currently reusable workflows do not support setting strategy property from the caller workflow.
     - name: Upload the package artifact for debugging and release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,12 +105,12 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-        TARBALL_PATH=$(find dist -name "*.tar.gz")
-        WHEEL_PATH=$(find dist -name "*.whl")
-        REQUIREMENTS_PATH=$(find dist -name "*-requirements.txt")
-        SBOM_PATH=$(find dist -name "*-sbom.json")
-        HTML_DOCS_PATH=$(find dist -name "*-docs-html.zip")
-        BUILD_EPOCH_PATH=$(find dist -name "*-build-epoch.txt")
+        TARBALL_PATH=$(find dist/ -type f -name "*.tar.gz")
+        WHEEL_PATH=$(find dist/ -type f -name "*.whl")
+        REQUIREMENTS_PATH=$(find dist/ -type f -name "*-requirements.txt")
+        SBOM_PATH=$(find dist/ -type f -name "*-sbom.json")
+        HTML_DOCS_PATH=$(find dist/ -type f -name "*-docs-html.zip")
+        BUILD_EPOCH_PATH=$(find dist/ -type f -name "*-build-epoch.txt")
         DIGEST=$(sha256sum $TARBALL_PATH $WHEEL_PATH $REQUIREMENTS_PATH $SBOM_PATH $HTML_DOCS_PATH $BUILD_EPOCH_PATH | base64 -w0)
         echo "Digest of artifacts is $DIGEST."
         echo "::set-output name=artifacts-sha256::$DIGEST"

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -46,6 +46,7 @@ jobs:
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
       with:
         python-version: ${{ matrix.python }}
+
     # For more details see the comment in build.yaml.
     - name: Create empty virtual environment for Actions
       run: mkdir .venv

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,3 +1,6 @@
+# Run CodeQL over the package. For more configuration options see codeql/codeql-config.yaml
+# and: https://github.com/github/codeql-action
+
 name: CodeQL
 on:
   push:
@@ -24,16 +27,15 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [python]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        language: [python]
         python: ['3.10']
-
     steps:
+
     - name: Harden Runner
       uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
       with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,10 +22,12 @@ jobs:
     name: Check PR title and commit messages
     runs-on: ubuntu-latest
     steps:
+
     - name: Check out repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         fetch-depth: 0
+
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
       with:
@@ -59,7 +61,3 @@ jobs:
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: read
-    # If the build workflow needs to access secrets, they need to be passed using `secrets: inherit`.
-    # See https://docs.github.com/en/actions/using-workflows/reusing-workflows to learn more.
-    # See  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
-    # for the security recommendations.

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -34,14 +34,14 @@ jobs:
         python-version: '3.10'
 
     # Install Commitizen without using the package's Makefile: that's much faster than
-    # creating a venv and installing heaps of dependencies that aren't required for
-    # this job. Then run Commitizen to check the title of the PR which triggered this
-    # workflow, and check all commit messages of the PR's branch. If any of the checks
-    # fails then this job fails.
+    # creating a venv and installing heaps of dependencies that aren't required for this job.
     - name: Set up Commitizen
       run: |
         pip install --upgrade pip wheel
         pip install 'commitizen ==2.32.1'
+
+    # Run Commitizen to check the title of the PR which triggered this workflow, and check
+    # all commit messages of the PR's branch. If any of the checks fails then this job fails.
     - name: Check PR title
       run: echo "$PR_TITLE" | cz check
       env:

--- a/.github/workflows/release-notifications.yaml
+++ b/.github/workflows/release-notifications.yaml
@@ -1,3 +1,5 @@
+# Send a Slack release notification.
+
 name: Release Notifications
 on:
   release:
@@ -15,6 +17,7 @@ jobs:
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
+
     - name: Harden Runner
       uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ jobs:
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: read
+
+  # On pushes to the 'main' branch create a new release by bumping the version
+  # and generating a change log. That's the new bump commit and associated tag.
   bump:
     needs: check
     if: github.ref == 'refs/heads/main'
@@ -29,45 +32,54 @@ jobs:
     permissions:
       contents: write
     steps:
+
     - name: Harden Runner
       uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Check out repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         fetch-depth: 0
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
+
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
       with:
         python-version: '3.10'
+
     - name: Set up Commitizen
       run: |
         pip install --upgrade pip wheel
         pip install 'commitizen ==2.32.1'
+
     - name: Set up user
       run: |
-        # Set up the GitHub user and email as author for the release commit.
         git config --global user.name $USER_NAME
         git config --global user.email $USER_EMAIL
-        git config --list --global
+        git config --list --global # For debug purposes.
+
     - name: Create changelog and bump
       run: cz bump --changelog --yes
+
     - name: Push the release
       run: |
         git push
         git push --tags
+
   # When triggered by the version bump commit, build the package and publish the release artifacts.
   build:
     if: github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, 'bump:')
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: read
+
+  # Generate the build provenance.
   provenance:
     needs: build
     # The generator should be referenced with a semantic version.
-    # The build will fail if we reference it using the commit sha.
+    # The build will fail if we reference it using the commit SHA.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
     with:
       base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
@@ -75,6 +87,9 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
+
+  # Create a new Release on Github from the verified build artifacts, and optionally
+  # publish the artifacts to a PyPI server.
   release:
     needs: [build, provenance]
     name: Release
@@ -82,32 +97,38 @@ jobs:
     permissions:
       contents: write # To publish release notes.
     steps:
+
     - name: Harden Runner
       uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Check out repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         fetch-depth: 0
+
     - name: Download provenance
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: ${{ needs.provenance.outputs.attestation-name }}
+
     - name: Download artifact
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: dist
+
+    # Verify hashes by first computing hashes for the artifacts and then comparing them
+    # against the hashes computed by the build job.
     - name: Verify the artifact hash
       env:
         ARTIFACT_HASH: ${{ needs.build.outputs.artifacts-sha256 }}
       run: |
         set -euo pipefail
         echo "Hash of package should be $ARTIFACT_HASH."
-        # Verify hashes by first computing hashes for the artifacts and
-        # then comparing them against the hashes computed by the build job.
         echo "$ARTIFACT_HASH" | base64 -d | sha256sum --strict --check --status || exit 1
+
     # Create the Release Notes using commitizen.
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
@@ -119,11 +140,13 @@ jobs:
         pip install 'commitizen ==2.32.1'
     - name: Create Release Notes
       run: cz changelog --dry-run $(cz version --project) > RELEASE_NOTES.md
+
+    # Create the release including the artifacts and the SLSA L3 provenance.
     - name: Upload assets
       env:
         GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-      # Create the release including the artifacts and the SLSA L3 provenance.
       run: TAG=`git describe --tags --abbrev=0` && gh release create $TAG dist/* ${{ needs.provenance.outputs.attestation-name }} --title $TAG --notes-file RELEASE_NOTES.md
+
     # Uncomment the following steps to publish to a PyPI server.
     # At the moment PyPI does not provide a mechanism to publish
     # the provenance. So, users have to download the provenance from
@@ -134,6 +157,7 @@ jobs:
     #   run: |
     #     pip install --upgrade pip wheel
     #     pip install 'twine ==4.0.1'
+
     # Pass the username, password, and PYPI repository URL via env variables.
     # Read the password from GitHub secrets or via other trusted mechanisms.
     # Do not hardcode the password in the workflow.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,11 +75,10 @@ jobs:
     permissions:
       contents: read
 
-  # Generate the build provenance.
+  # Generate the build provenance. The generator should be referenced with a semantic version.
+  # The build will fail if we reference it using the commit SHA.
   provenance:
     needs: build
-    # The generator should be referenced with a semantic version.
-    # The build will fail if we reference it using the commit SHA.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
     with:
       base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
@@ -162,8 +161,8 @@ jobs:
     # Read the password from GitHub secrets or via other trusted mechanisms.
     # Do not hardcode the password in the workflow.
     # - name: Publish to PyPI server
-    #   run: |
-    #     export TWINE_USERNAME=<USERNAME>
-    #     export TWINE_PASSWORD=<PASSWORD>
-    #     export TWINE_REPOSITORY_URL=<REPOSITORY_URL>
-    #     twine upload --verbose dist/*.tar.gz dist/*.whl
+    #   run: twine upload --verbose dist/*.tar.gz dist/*.whl
+    #   env:
+    #     TWINE_USERNAME=<USERNAME>
+    #     TWINE_PASSWORD=<PASSWORD>
+    #     TWINE_REPOSITORY_URL=<REPOSITORY_URL>

--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -1,3 +1,5 @@
+# Run Scorecard for this repository to further check and harden software and process.
+
 name: Scorecards supply-chain security
 on:
   # Only the default branch is supported.
@@ -19,8 +21,8 @@ jobs:
       security-events: write
       actions: read
       contents: read
-
     steps:
+
     - name: Harden Runner
       uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95 # v1.4.5
       with:


### PR DESCRIPTION
One more thought: it looks like Github [is not able to share environment variables _between_ workflows](https://docs.github.com/en/actions/learn-github-actions/environment-variables). But I wonder if perhaps we should move “global” variables like this:

https://github.com/jenstroeger/python-package-template/blob/ceee4a7b803747f9e168f188227345685d984c5b/.github/workflows/release.yaml#L14-L17

to the only step that actually uses them

https://github.com/jenstroeger/python-package-template/blob/ceee4a7b803747f9e168f188227345685d984c5b/.github/workflows/release.yaml#L57-L61

Simply for the sake of tightening the scope.