### PR TITLE
fix: use simple expansion consistently for all Makefile variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@
 SHELL := /usr/bin/env bash
 
 # Set the package's name and version for use throughout the Makefile.
-PACKAGE_NAME=package
+PACKAGE_NAME := package
 ifeq ($(wildcard .venv/upgraded-on),)
-  PACKAGE_VERSION=unknown
+  PACKAGE_VERSION := unknown
 else
-  PACKAGE_VERSION=$(shell python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
+  PACKAGE_VERSION := $(shell python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
 endif
 
 # This variable contains the first goal that matches any of the listed goals


### PR DESCRIPTION
Use [simply expanded variables](https://www.gnu.org/software/make/manual/html_node/Flavors.html) for _all_ variable expansions because there’s no need to get any more sophisticated.