### PR TITLE
fix: a Makefile’s SHELL variable is not an executable shebang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 # Use bash as the shell when executing a rule's recipe. For more details:
 # https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
-# https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang
-SHELL := /usr/bin/env bash
+SHELL := bash
+.SHELLFLAGS += -e
 
 # Set the package's name and version for use throughout the Makefile.
 PACKAGE_NAME=package

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 # Use bash as the shell when executing a rule's recipe. For more details:
 # https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
 SHELL := bash
-.SHELLFLAGS += -e
 
 # Set the package's name and version for use throughout the Makefile.
 PACKAGE_NAME=package


### PR DESCRIPTION
I stumbled upon issues when I played with the [`.ONESHELL:` special target](https://www.gnu.org/software/make/manual/html_node/One-Shell.html):
```
> make audit
make: /usr/bin/env bash: No such file or directory
...
```
Documentation on this is a little sparse, I thought.

<hr>

I also think we should consider using the special target `.ONESHELL:`: it runs the entire recipe in a _single_ shell which would allow us to set & use environment variables within that recipe. So far we’ve danced around `make` running every recipe line in its own shell, and that has complicated some of our process. In that context, it would also make sense to discuss [`.EXPORT_ALL_VARIABLES:`](https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html).

There’s also an option to [silence `make`’s command-line echoing](https://www.gnu.org/software/make/manual/html_node/Echoing.html), which may be usful?