### PR TITLE
refactor(ci): allow release when provenance generation fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,15 +165,17 @@ jobs:
   # https://github.com/slsa-framework/slsa-github-generator/issues/942
   provenance:
     needs: [build, release]
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
       base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
-      compile-generator: true
+      compile-generator: true # Build the generator from source.
+      # Set private-repository to true for private repositories. Note that the repository name is
+      # uploaded as part of the transparency log entry on the public Rekor instance (rekor.sigstore.dev).
+      private-repository: false
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-
 
   # Publish the SLSA provenance as the GitHub release asset.
   publish_provenance:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,23 +75,13 @@ jobs:
     permissions:
       contents: read
 
-  # Generate the build provenance. The generator should be referenced with a semantic version.
-  # The build will fail if we reference it using the commit SHA.
-  provenance:
-    needs: build
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
-    with:
-      base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
-    permissions:
-      actions: read # To read the workflow path.
-      id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
-
   # Create a new Release on Github from the verified build artifacts, and optionally
   # publish the artifacts to a PyPI server.
   release:
-    needs: [build, provenance]
+    needs: [build]
     name: Release
+    outputs:
+      release-tag: ${{ steps.upload-assets.outputs.release-tag }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # To publish release notes.
@@ -106,11 +96,6 @@ jobs:
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       with:
         fetch-depth: 0
-
-    - name: Download provenance
-      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
-      with:
-        name: ${{ needs.provenance.outputs.attestation-name }}
 
     - name: Download artifact
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
@@ -133,18 +118,24 @@ jobs:
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5 # v4.2.0
       with:
         python-version: '3.10'
+
     - name: Set up Commitizen
       run: |
         pip install --upgrade pip wheel
         pip install 'commitizen ==2.32.1'
+
     - name: Create Release Notes
       run: cz changelog --dry-run $(cz version --project) > RELEASE_NOTES.md
 
     # Create the release including the artifacts and the SLSA L3 provenance.
     - name: Upload assets
+      id: upload-assets
       env:
         GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-      run: TAG=`git describe --tags --abbrev=0` && gh release create $TAG dist/* ${{ needs.provenance.outputs.attestation-name }} --title $TAG --notes-file RELEASE_NOTES.md
+      run: |
+        TAG=`git describe --tags --abbrev=0`
+        gh release create $TAG dist/* --title $TAG --notes-file RELEASE_NOTES.md
+        echo "release-tag=$TAG" >> $GITHUB_OUTPUT
 
     # Uncomment the following steps to publish to a PyPI server.
     # At the moment PyPI does not provide a mechanism to publish
@@ -166,3 +157,49 @@ jobs:
     #     TWINE_USERNAME=<USERNAME>
     #     TWINE_PASSWORD=<PASSWORD>
     #     TWINE_REPOSITORY_URL=<REPOSITORY_URL>
+
+  # Generate the build provenance. The generator should be referenced with a semantic version.
+  # The build will fail if we reference it using the commit SHA. To avoid using a pre-built
+  # provenance generator which depends on an external service Rekor (https://github.com/sigstore/rekor)
+  # we build this generator from source for now. For more information see this discussion:
+  # https://github.com/slsa-framework/slsa-github-generator/issues/942
+  provenance:
+    needs: [build, release]
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
+      compile-generator: true
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+
+
+  # Publish the SLSA provenance as the GitHub release asset.
+  publish_provenance:
+    needs: [release, provenance]
+    name: Publish provenance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To publish release notes.
+    steps:
+
+    - name: Harden Runner
+      uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1.5.0
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - name: Check out repository
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      with:
+        fetch-depth: 0
+
+    - name: Download provenance
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+      with:
+        name: ${{ needs.provenance.outputs.attestation-name }}
+
+    - name: Upload provenance
+      run: gh release upload ${{ needs.release.outputs.release-tag }} ${{ needs.provenance.outputs.attestation-name }}
+      env:
+        GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR decouples the release and provenance generation and allows the release to proceed even if provenance generation fails.