### PR TITLE
fix: exit Makefile gracefully if an inactive venv was found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ venv:
 	  echo "Found an activated Python virtual environment, exiting" && exit 1; \
 	fi
 	if [ -d .venv/ ]; then \
-	  echo "Found an inactive Python virtual environment, please activate" && exit 1; \
+	  echo "Found an inactive Python virtual environment, please activate or nuke it" && exit 1; \
 	fi
 	if [ -z "${PYTHON}" ]; then \
 	  echo "Creating virtual envirnoment in .venv/ for python3.10"; \

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ venv:
 	if [ ! -z "${VIRTUAL_ENV}" ]; then \
 	  echo "Found an activated Python virtual environment, exiting" && exit 1; \
 	fi
+	if [ -d .venv/ ]; then \
+	  echo "Found an inactive Python virtual environment, please activate" && exit 1; \
+	fi
 	if [ -z "${PYTHON}" ]; then \
 	  echo "Creating virtual envirnoment in .venv/ for python3.10"; \
 	  python3.10 -m venv --upgrade-deps --prompt . .venv; \


### PR DESCRIPTION
It might happen that a user runs
```
(project) ~/some/path > deactivate
~/some/path > make venv
```
in which case we want to exit gracefully instead of installing a new venv over the existing one.