### PR TITLE
fix: determine an activated venv correctly when running make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := bash
 
 # Set the package's name and version for use throughout the Makefile.
 PACKAGE_NAME := package
-ifeq ($(wildcard .venv/upgraded-on),)
+ifeq ($(origin VIRTUAL_ENV),undefined)
   PACKAGE_VERSION := unknown
 else
   PACKAGE_VERSION := $(shell python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')


### PR DESCRIPTION
Just like here

https://github.com/jenstroeger/python-package-template/blob/2adf30a7250ce8a6061f325f7aac2ad78777492a/Makefile#L36-L37

we want to make sure we determine an activated virtual env correctly by its environment variable, not whether a path & file exists (which is no indicator as to if the venv was actually activated).