### PR TITLE
fix: run pytest hook on unstaged files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ check:
 # Run all unit tests.
 .PHONY: test
 test:
-	pre-commit run pytest --hook-stage push
+	pre-commit run pytest --hook-stage push --files test/
 
 # Build a source distribution package and a binary wheel distribution artifact.
 # When building these artifacts, we need the environment variable SOURCE_DATE_EPOCH

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,8 @@ check-mypy:
 check:
 	pre-commit run --all-files
 
-# Run all unit tests.
+# Run all unit tests. The --files option avoids stashing but passes files; however,
+# the hook setup itself does not pass files to pytest (see .pre-commit-config.yaml).
 .PHONY: test
 test:
 	pre-commit run pytest --hook-stage push --files test/


### PR DESCRIPTION
Note that all `make check` variants run their `pre-commit` hooks on _unstaged_ files by using the [`--all-files`](https://pre-commit.com/#pre-commit-run) command line option:

https://github.com/jenstroeger/python-package-template/blob/f41b0e6a46061081370253b9ac17a1b62b5c85dc/Makefile#L157-L166

However, running `make test` does not specify that option

https://github.com/jenstroeger/python-package-template/blob/f41b0e6a46061081370253b9ac17a1b62b5c85dc/Makefile#L170-L171

and thus _stashes_ changes before running:
```
> make test
pre-commit run pytest --hook-stage push
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /path/to/.cache/pre-commit/patch1666240262-62070.
Run unit tests...........................................................Passed
- hook id: pytest
- duration: 0.9s

...
============================== 1 passed in 0.35s ===============================

[INFO] Restored changes from /path/to/.cache/pre-commit/patch1666240262-62070.
```
This change uses the `--files` command line option (which is similar to the `--all-files`) and now `make test` no longer stashes changes before running.