### PR TITLE
fix(ci): fix actionlint warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,7 @@ jobs:
         SBOM_PATH=$(find dist/ -type f -name "*-sbom.json")
         HTML_DOCS_PATH=$(find dist/ -type f -name "*-docs-html.zip")
         BUILD_EPOCH_PATH=$(find dist/ -type f -name "*-build-epoch.txt")
-        DIGEST=$(sha256sum $TARBALL_PATH $WHEEL_PATH $REQUIREMENTS_PATH $SBOM_PATH $HTML_DOCS_PATH $BUILD_EPOCH_PATH | base64 -w0)
+        DIGEST=$(sha256sum "$TARBALL_PATH" "$WHEEL_PATH" "$REQUIREMENTS_PATH" "$SBOM_PATH" "$HTML_DOCS_PATH" "$BUILD_EPOCH_PATH" | base64 -w0)
         echo "Digest of artifacts is $DIGEST."
         echo "::set-output name=artifacts-sha256::$DIGEST"
 

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -47,9 +47,9 @@ jobs:
         PR_TITLE: ${{ github.event.pull_request.title }}
     - name: Check PR commit messages
       run: |
-        git remote add other $PR_HEAD_REPO_CLONE_URL
+        git remote add other "$PR_HEAD_REPO_CLONE_URL"
         git fetch other
-        cz check --rev-range origin/$PR_BASE_REF..other/$PR_HEAD_REF
+        cz check --rev-range "origin/$PR_BASE_REF..other/$PR_HEAD_REF"
       env:
         PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,8 +56,8 @@ jobs:
 
     - name: Set up user
       run: |
-        git config --global user.name $USER_NAME
-        git config --global user.email $USER_EMAIL
+        git config --global user.name "$USER_NAME"
+        git config --global user.email "$USER_EMAIL"
         git config --list --global # For debug purposes.
 
     - name: Create changelog and bump
@@ -125,7 +125,7 @@ jobs:
         pip install 'commitizen ==2.32.1'
 
     - name: Create Release Notes
-      run: cz changelog --dry-run $(cz version --project) > RELEASE_NOTES.md
+      run: cz changelog --dry-run "$(cz version --project)" > RELEASE_NOTES.md
 
     # Create the release including the artifacts and the SLSA L3 provenance.
     - name: Upload assets
@@ -133,9 +133,9 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
       run: |
-        TAG=`git describe --tags --abbrev=0`
-        gh release create $TAG dist/* --title $TAG --notes-file RELEASE_NOTES.md
-        echo "release-tag=$TAG" >> $GITHUB_OUTPUT
+        TAG=$(git describe --tags --abbrev=0)
+        gh release create "$TAG" dist/* --title "$TAG" --notes-file RELEASE_NOTES.md
+        echo "release-tag=$TAG" >> "$GITHUB_OUTPUT"
 
     # Uncomment the following steps to publish to a PyPI server.
     # At the moment PyPI does not provide a mechanism to publish


### PR DESCRIPTION
Ran [actionlint](https://github.com/rhysd/actionlint) which used [shellcheck](https://www.shellcheck.net/), and fixed the warnings. (See also issue https://github.com/jenstroeger/python-package-template/issues/58.)