### PR TITLE
fix(ci): ignore CVE GHSA-w596-4wvx-j9j6 until that’s properly resolved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,15 @@ requirements.txt: pyproject.toml
 # editable mode (like the one in development here) because they may not have
 # a PyPI entry; also print out CVE description and potential fixes if audit
 # found an issue.
+# Note that we temporarily ignore GHSA-w596-4wvx-j9j6 until it is resolved properly:
+# https://github.com/pytest-dev/py/issues/287
+# https://github.com/pypa/pip-audit/issues/388#issuecomment-1290411582
 .PHONY: audit
 audit:
 	if ! `python -c "import pip_audit" &> /dev/null`; then \
 	  echo "No package pip_audit installed, upgrade your environment!" && exit 1; \
 	fi;
-	python -m pip_audit --skip-editable --desc on --fix --dry-run
+	python -m pip_audit --skip-editable --desc on --fix --dry-run --ignore-vuln GHSA-w596-4wvx-j9j6
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy


### PR DESCRIPTION
See also the original issue https://github.com/pytest-dev/py/issues/287, and follow-up fixes to `pip-audit` https://github.com/pypa/pip-audit/issues/385 and https://github.com/pypa/pip-audit/issues/388.