### PR TITLE
fix: update pytest to drop dependency on vulnerable py package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,9 @@ hooks = [
 # Note that the `custom_exit_code` and `env` plugins may currently be unmaintained.
 test = [
     "hypothesis >=6.21.0,<=6.54.4",
-    "pytest >=7.1.2,<8.0.0",
+    "pytest >=7.2.0,<8.0.0",
     "pytest-custom_exit_code ==0.3.0",
-    "pytest-cov ==3.0.0",
+    "pytest-cov ==4.0.0",
     "pytest-env ==0.6.2",
 ]
 


### PR DESCRIPTION
See also: https://github.com/pytest-dev/py/issues/287#issuecomment-1290407715

This PR supersedes https://github.com/jenstroeger/python-package-template/pull/353