### PR TITLE
fix: don’t nuke an activated virtual environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,6 @@ nuke-caches: clean
 	find tests/ -type d -name __pycache__ -exec rm -fr {} +
 nuke: nuke-caches
 	if [ ! -z "${VIRTUAL_ENV}" ]; then \
-	  echo "Deactivating and nuking virtual environment!"; \
-	  deactivate; \
-	  rm -fr .venv; \
+	  echo "Please deactivate the virtual environment first!" && exit 1; \
 	fi
+	rm -fr .venv/


### PR DESCRIPTION
So… calling `make nuke` usually fails because `deactivate` can’t be found when running `make`. That is because `deactivate` is actually a function sourced by the `activate` script
```shell
 > type -t deactivate 
function
```
and therefore it’s not available in the subprocess that runs the shell in the Makefile. This change prevents that failure, and instead just aborts `make` cleanly if the venv is activated.