### PR TITLE
feat(ci): add Dependency and License checks to build workflow

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -65,6 +65,14 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Dependency review scans for introduced vulnerabilities and compatible licenses.
+    - name: Dependency Review
+      uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1
+      with:
+        fail-on-severity: moderate
+        license-check: true
+        vulnerability-check: true
+
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -67,11 +67,13 @@ jobs:
 
     # Dependency review scans for introduced vulnerabilities and compatible licenses.
     - name: Dependency Review
-      uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
       with:
         fail-on-severity: moderate
-        license-check: true
         vulnerability-check: true
+        license-check: true
+        allow-licenses:
+        comment-summary-in-pr: always
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -72,7 +72,7 @@ jobs:
         fail-on-severity: moderate
         vulnerability-check: true
         license-check: true
-        allow-licenses:
+        # allow-licenses:
         comment-summary-in-pr: always
 
     - name: Set up Python


### PR DESCRIPTION
I stumbled upon the [dependency-review-action](https://github.com/actions/dependency-review-action) which looked useful. Not sure if `build.yaml` is a good place, or better [`pr-change-set.yaml`](https://github.com/jenstroeger/python-package-template/blob/main/.github/workflows/pr-change-set.yaml). What do you think, @behnazh?