### PR TITLE
fix: determine package version even in deactivated venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,9 @@
 # https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
 SHELL := bash
 
-# Set the package's name and version for use throughout the Makefile. If the
-# version can not be determined then error out.
+# Set the package's name and version for use throughout the Makefile.
 PACKAGE_NAME := package
-ifneq ($(origin VIRTUAL_ENV),undefined)
-  PACKAGE_VERSION := $(shell python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
-else ifneq ($(wildcard .venv/upgraded-on),)
-  PACKAGE_VERSION := $(shell .venv/bin/python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
-else
-  $(error Unable to determine package version)
-endif
+PACKAGE_VERSION := $(shell python -c $$'try: import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__);\nexcept: print("unknown");')
 
 # This variable contains the first goal that matches any of the listed goals
 # here, else it contains an empty string. The net effect is to filter out

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,15 @@
 # https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html
 SHELL := bash
 
-# Set the package's name and version for use throughout the Makefile.
+# Set the package's name and version for use throughout the Makefile. If the
+# version can not be determined then error out.
 PACKAGE_NAME := package
 ifneq ($(origin VIRTUAL_ENV),undefined)
   PACKAGE_VERSION := $(shell python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
 else ifneq ($(wildcard .venv/upgraded-on),)
   PACKAGE_VERSION := $(shell .venv/bin/python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
 else
-  PACKAGE_VERSION := unknown
+  $(error Unable to determine package version)
 endif
 
 # This variable contains the first goal that matches any of the listed goals

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ SHELL := bash
 
 # Set the package's name and version for use throughout the Makefile.
 PACKAGE_NAME := package
-ifeq ($(origin VIRTUAL_ENV),undefined)
-  PACKAGE_VERSION := unknown
-else
+ifneq ($(origin VIRTUAL_ENV),undefined)
   PACKAGE_VERSION := $(shell python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
+else ifneq ($(wildcard .venv/upgraded-on),)
+  PACKAGE_VERSION := $(shell .venv/bin/python -c 'import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__)')
+else
+  PACKAGE_VERSION := unknown
 endif
 
 # This variable contains the first goal that matches any of the listed goals


### PR DESCRIPTION
Thank you @behnazh for noticing the regression with [v2.4.1](https://github.com/jenstroeger/python-package-template/releases/tag/v2.4.1), introduced by PR https://github.com/jenstroeger/python-package-template/pull/346. The problem is (still and again 🤦🏻‍♂️) that we don’t set up a venv in a Github runner and therefore we shouldn’t rely on the `VIRTUAL_ENV` environment variable.

This change expands the Python command so that the command _always_ returns a package version string (which may be `"unknown"`) instead of failing the `import package`.

I think it’s safe to expect `"unknown"` for `make venv` (or its Action equivalent)

https://github.com/jenstroeger/python-package-template/blob/7bf474b781efa1fb0e69dcf31f968675695f10bc/.github/workflows/build.yaml#L70-L71

and `make setup`

https://github.com/jenstroeger/python-package-template/blob/7bf474b781efa1fb0e69dcf31f968675695f10bc/.github/workflows/build.yaml#L72-L73

because the package hasn’t been installed yet, and therefore its version can’t be determined.

However, after `make setup` the package’s version can be determined safely—with or without virtual environment. For example, the artifacts attached to workflow run [3488321082](https://github.com/jenstroeger/python-package-template/actions/runs/3488321082) indeed contain the correct package version number again:

![pkg](https://user-images.githubusercontent.com/12053937/202451580-c5c45a6b-1f6b-4e7a-a4b5-d4169641c9a5.jpg)