### PR TITLE
fix(ci): update deprecated SLSA provenance generator, again

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,7 +165,7 @@ jobs:
   # https://github.com/slsa-framework/slsa-github-generator/issues/942
   provenance:
     needs: [build, release]
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
       compile-generator: true # Build the generator from source.


### PR DESCRIPTION
It’s becoming really quite miserable how often those SLSA folks break their Github Action, and how carelessly they’re versioning it. Apparently, any release [older than v1.2.2](https://github.com/slsa-framework/slsa-github-generator/releases) is now deprecated.