### PR TITLE
fix(ci): make Release Notification a reusable workflow to avoid artifact race

### DIFF
--- a/.github/workflows/_release-notifications.yaml
+++ b/.github/workflows/_release-notifications.yaml
@@ -2,9 +2,20 @@
 
 name: Release Notifications
 on:
-  release:
-    types:
-    - released
+  workflow_call:
+    inputs:
+      repo_name:
+        required: true
+        type: string
+      release_tag:
+        required: true
+        type: string
+      release_url:
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
 
 # Grant no permissions to this workflow.
 permissions: {}
@@ -28,13 +39,13 @@ jobs:
       with:
         payload: |
           {
-            "text": "${{ github.event.repository.name }} published a new release ${{ github.event.release.tag_name }}",
+            "text": "${{ inputs.repo_name }} published a new release ${{ inputs.release_tag }}",
             "blocks": [
               {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*${{ github.event.repository.name }}* published a new release <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}>"
+                  "text": "*${{ inputs.repo_name }}* published a new release <${{ inputs.release_url }}|${{ inputs.release_tag }}>"
                 }
               }
             ]

--- a/.github/workflows/_release-notifications.yaml
+++ b/.github/workflows/_release-notifications.yaml
@@ -1,4 +1,5 @@
-# Send a Slack release notification.
+# Send a Slack release notification. Instructions to set up Slack to receive
+# messages can be found here: https://github.com/slackapi/slack-github-action#setup-2
 
 name: Release Notifications
 on:
@@ -23,21 +24,15 @@ permissions: {}
 jobs:
   slack:
     name: Slack release notification
-    # Remove the next line after your Slack app has been set up. See also:
-    # https://github.com/slackapi/slack-github-action#setup-2
-    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
 
-    - name: Harden Runner
-      uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1.5.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
     - name: Notify via Slack
-      uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # v1.21.0
-      with:
-        payload: |
+      run: |
+        curl --header "Content-Type: application/json; charset=UTF-8" --request POST --data "$SLACK_WEBHOOK_MSG" "$SLACK_WEBHOOK_URL"
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_MSG: |
           {
             "text": "${{ inputs.repo_name }} published a new release ${{ inputs.release_tag }}",
             "blocks": [
@@ -50,6 +45,3 @@ jobs:
               }
             ]
           }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,7 +209,9 @@ jobs:
         GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
 
   # Send out release notifications after the Release was published on GitHub.
+  # Uncomment the `if` to disable sending release notifications.
   notifications:
+    # if: ${{ false }}
     needs: [release]
     name: Send Release notifications
     uses: ./.github/workflows/_release-notifications.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,6 @@ jobs:
   # https://github.com/slsa-framework/slsa-github-generator/issues/942
   provenance:
     needs: [build, release]
-    name: Generate provenance
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,7 @@ jobs:
     name: Release
     outputs:
       release-tag: ${{ steps.upload-assets.outputs.release-tag }}
+      release-url: ${{ steps.upload-assets.outputs.release-url }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # To publish release notes.
@@ -136,6 +137,7 @@ jobs:
         TAG=$(git describe --tags --abbrev=0)
         gh release create "$TAG" dist/* --title "$TAG" --notes-file RELEASE_NOTES.md
         echo "release-tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "release-url=$(gh release view """$TAG""" --json url --jq .url)" >> "$GITHUB_OUTPUT"
 
     # Uncomment the following steps to publish to a PyPI server.
     # At the moment PyPI does not provide a mechanism to publish
@@ -165,6 +167,7 @@ jobs:
   # https://github.com/slsa-framework/slsa-github-generator/issues/942
   provenance:
     needs: [build, release]
+    name: Generate provenance
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: ${{ needs.build.outputs.artifacts-sha256 }}
@@ -205,3 +208,17 @@ jobs:
       run: gh release upload ${{ needs.release.outputs.release-tag }} ${{ needs.provenance.outputs.provenance-name }}
       env:
         GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+  # Send out release notifications after the Release was published on GitHub.
+  notifications:
+    needs: [release]
+    name: Send Release notifications
+    uses: ./.github/workflows/_release-notifications.yaml
+    permissions:
+      contents: read
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      release_tag: ${{ needs.release.outputs.release-tag }}
+      release_url: ${{ needs.release.outputs.release-url }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ open docs/_build/html/index.html
 
 To enable automation for [semantic versioning](https://semver.org/), package publishing, and changelog generation it is important to use meaningful [conventional commit messages](https://www.conventionalcommits.org/)! This package template already has a built-in semantic release support enabled which is set up to take care of all three of these aspects — every time changes are merged into the `main` branch.
 
-If you’d like to receive Slack notifications whenever a new release is published, follow the comments in the [Release Notification](https://github.com/jenstroeger/python-package-template/tree/main/.github/workflows/release-notifications.yaml) Action and set up a Slack bot by following [the instructions here](https://github.com/slackapi/slack-github-action#setup-2).
+If you’d like to receive Slack notifications whenever a new release is published, follow the comments in the [Release Notification](https://github.com/jenstroeger/python-package-template/tree/main/.github/workflows/_release-notifications.yaml) Action and set up a Slack bot by following [the instructions here](https://github.com/slackapi/slack-github-action#setup-2).
 
 In order to build a distribution of your package locally instead of publishing it through the Github Actions workflow, you can simply call:
 


### PR DESCRIPTION
If triggered by the [`release[released]`](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#releaseevent) event then the [Release Notification workflow](https://github.com/jenstroeger/python-package-template/blob/main/.github/workflows/release-notifications.yaml) ([code](https://github.com/jenstroeger/python-package-template/blob/7bf474b781efa1fb0e69dcf31f968675695f10bc/.github/workflows/release.yaml#L137)) starts running before the [Release workflow](https://github.com/jenstroeger/python-package-template/blob/main/.github/workflows/release.yaml) finishes. That can lead to a race condition where the release artifacts of the Release workflow are not yet available to workflows triggered by the `release[released]` event.

Using a reusable workflow addresses that race condition and enables us to pass artifacts more easily.

Closes #355 