### PR TITLE
chore(ci): use long command-line option to improve readability

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
       run: |
         set -euo pipefail
         echo "Hash of package should be $ARTIFACT_HASH."
-        echo "$ARTIFACT_HASH" | base64 -d | sha256sum --strict --check --status || exit 1
+        echo "$ARTIFACT_HASH" | base64 --decode | sha256sum --strict --check --status || exit 1
 
     # Create the Release Notes using commitizen.
     - name: Set up Python


### PR DESCRIPTION
From the [`base64` man page](https://linux.die.net/man/1/base64):
```
       -d, --decode
              decode data
```