### PR TITLE
fix: line-length checks are now a bit more tolerant using Bugbear only

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,8 +3,9 @@
 #
 # Disabling the following noise:
 # D105: Missing docstring in magic method
+# E501: line too long, managed better by Bugbear's B950
 [flake8]
-ignore = D105
+ignore = D105, E501
 per-file-ignores =
 max-line-length = 120
 show-source = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ ignore_missing_imports = true
 fail-under = 10.0
 disable = [
     "fixme",
+    "line-too-long",  # Replaced by Flake8 Bugbear B950 check.
     "too-few-public-methods",
     "too-many-ancestors",
     "too-many-arguments",


### PR DESCRIPTION
Both `pylint`’s [line-too-long](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/line-too-long.html) check and `flake8`’s [E501](https://www.flake8rules.com/rules/E501.html) are hard limits—one character over the configured line limit (120 characters in our case) triggers the error.

Bugbear’s [B950](https://github.com/PyCQA/flake8-bugbear) is more flexible in that…

> This is a pragmatic equivalent of pycodestyle's E501: it considers "max-line-length" but only triggers when the value has been exceeded by more than 10%. You will no longer be forced to reformat code due to the closing parenthesis being one character too far to satisfy the linter. At the same time, if you do significantly violate the line length, you will receive a message that states what the actual limit is. This is inspired by Raymond Hettinger's ["Beyond PEP 8" talk](https://www.youtube.com/watch?v=wf-BqAjZb8M) and highway patrol not stopping you if you drive < 5mph too fast. Disable E501 to avoid duplicate warnings.

This change disables both `pylint`’s and `flake8`’s line checks and uses Bugbear’s only.