### PR TITLE
chore(ci): add twine command line argument to rerun workflow more easily

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
     # Read the password from GitHub secrets or via other trusted mechanisms.
     # Do not hardcode the password in the workflow.
     # - name: Publish to PyPI server
-    #   run: twine upload --verbose dist/*.tar.gz dist/*.whl
+    #   run: twine upload --verbose --skip-existing dist/*.tar.gz dist/*.whl
     #   env:
     #     TWINE_USERNAME=<USERNAME>
     #     TWINE_PASSWORD=<PASSWORD>


### PR DESCRIPTION
Rerunning the Release workflow may cause a re-upload of the build-artifacts. By default [`twine`](https://twine.readthedocs.io/) fails when uploading an existing package, so let’s allow that so that the workflow can rerun successfully.