### PR TITLE
refactor(test): configure warnings for pytest through pyproject.toml only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,8 +155,8 @@ repos:
   hooks:
   - id: pytest
     name: Run unit tests
-    entry: python -W always::DeprecationWarning -m pytest -c pyproject.toml --cov-config pyproject.toml
-    language: system
+    entry: pytest -c pyproject.toml --cov-config pyproject.toml
+    language: python
     verbose: true
     always_run: true
     pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [
     "tests",
 ]
-env = [
-    "PYTHONWARNINGS=always::DeprecationWarning",
+env = []
+filterwarnings = [
+    "always::DeprecationWarning",
 ]


### PR DESCRIPTION
We should not configure [Python warnings](https://docs.python.org/3/library/warnings.html) for `pytest` in two different places, esp. if `pytest` sports a [`filterwarnings` configuration option](https://docs.pytest.org/en/7.1.x/reference/reference.html#confval-filterwarnings).