### PR TITLE
chore: collapse verbose pytest tracebacks to native Python format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ max-line-length = 120
 # https://docs.pytest.org/en/latest/reference/reference.html#command-line-flags
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "--verbose --doctest-modules --hypothesis-show-statistics --hypothesis-explain --hypothesis-verbosity verbose -ra --cov package"  # Consider adding --pdb
+addopts = "--verbose --doctest-modules --tb native --hypothesis-show-statistics --hypothesis-explain --hypothesis-verbosity verbose -ra --cov package"  # Consider adding --pdb
 doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [
     "tests",


### PR DESCRIPTION
Personally I always found the “long” `pytest` tracebacks intrusive and obscure, and much prefer to work with Python’s native traceback style. See also the [docs](https://docs.pytest.org/en/7.2.x/how-to/output.html#modifying-python-traceback-printing).