### PR TITLE
fix: call explicitly Python3 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := bash
 
 # Set the package's name and version for use throughout the Makefile.
 PACKAGE_NAME := package
-PACKAGE_VERSION := $(shell python -c $$'try: import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__);\nexcept: print("unknown");')
+PACKAGE_VERSION := $(shell python3 -c $$'try: import $(PACKAGE_NAME); print($(PACKAGE_NAME).__version__);\nexcept: print("unknown");')
 
 # This variable contains the first goal that matches any of the listed goals
 # here, else it contains an empty string. The net effect is to filter out


### PR DESCRIPTION
Turns out that on new(er) Macs there is no `python` but a `python3`. I suspect that’s to avoid collisions with user-installed `python2` versions (v2.7 the current, last maintained one).

Leaving this PR as a Draft for discussion.