### PR TITLE
chore(deps): update cyclonedx-bom and remove deprecated CLI command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ upgrade-quiet:
 # Generate a Software Bill of Materials (SBOM).
 .PHONY: sbom
 sbom: requirements
-	cyclonedx-bom --force --requirements --format json --output dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-sbom.json
+	cyclonedx-py --force --requirements --format json --output dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-sbom.json
 
 # Generate a requirements.txt file containing version and integrity hashes for all
 # packages currently installed in the virtual environment. There's no easy way to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "mypy >=0.921,<1.1",
     "pip-audit >=2.4.4,<3.0.0",
     "pylint >=2.9.3,<2.16.3",
-    "cyclonedx-bom >=3.5.0,<4.0.0",
+    "cyclonedx-bom >=3.11.0,<4.0.0",
 ]
 docs = [
     "sphinx >=5.1.1,<7.0.0",


### PR DESCRIPTION
This PR updates `cyclonedx-bom` Python module and uses `cyclonedx-py` instead of the deprecated `cyclonedx-bom` CLI command.

For more information see: https://github.com/CycloneDX/cyclonedx-python/releases/tag/v3.11.0.
