### PR TITLE
fix: make Black, Flake8, Sphinx play nice together by tweaking a few Flake8 settings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,11 +5,13 @@
 # https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#flake8
 [flake8]
 
-# Enable Bugbear's extended opinionated checks.
-# https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings
+# Enable a few additional checks.
 #
-# Enable W504: line break after binary operator (Black compliant)
+# https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings
+# B9: Bugbear's extended opinionated checks
+#
 # https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+# W504: line break after binary operator (Black compliant)
 extend-select = B9, W504
 
 # Disable several warnings that don't play nice with PEP8 or Black,
@@ -32,7 +34,7 @@ per-file-ignores =
 max-line-length = 120
 show-source = true
 
-# Ensure that Flake8 warnings are silenced correctly.
+# Ensure that Flake8 warnings are silenced correctly:
 # https://github.com/plinss/flake8-noqa#options
 noqa-require-code = true
 

--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,7 @@ extend-select = B9, W504
 #
 # https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 # E203: whitespace before ‘,’, ‘;’, or ‘:’ (not Black compliant)
-# E501: line too long, managed better by Bugbear's B950
+# E501: line too long (managed better by Bugbear's B950)
 # W503: line break before binary operator (not Black compliant)
 #
 # https://github.com/peterjc/flake8-rst-docstrings#configuration

--- a/.flake8
+++ b/.flake8
@@ -22,7 +22,10 @@ extend-select = B9, W504
 # E203: whitespace before ‘,’, ‘;’, or ‘:’ (not Black compliant)
 # E501: line too long, managed better by Bugbear's B950
 # W503: line break before binary operator (not Black compliant)
-ignore = D105, E203, E501, W503
+#
+# https://github.com/peterjc/flake8-rst-docstrings#configuration
+# RST307: Error in "XXX" directive
+ignore = D105, E203, E501, RST307, W503
 per-file-ignores =
 
 # More assorted goodness.
@@ -32,3 +35,9 @@ show-source = true
 # Ensure that Flake8 warnings are silenced correctly.
 # https://github.com/plinss/flake8-noqa#options
 noqa-require-code = true
+
+# Ensure that Sphinx extensions of .rst are recognized:
+# https://github.com/peterjc/flake8-rst-docstrings#configuration
+rst-roles = class, func, ref
+rst-directives = envvar, exception
+rst-substitutions = version

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
-# Unfortunately, flake8 does not support pyproject.toml configuration.
+# Unfortunately, Flake8 does not support pyproject.toml configuration.
 # https://github.com/PyCQA/flake8/issues/234
 #
 # More details regarding Flake8 and Black interplay:
@@ -12,7 +12,7 @@
 # https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 extend-select = B9, W504
 
-# Disabling several warnings that don't play nice with PEP8 or Black,
+# Disable several warnings that don't play nice with PEP8 or Black,
 # or that are a bit of a nuisance in general.
 #
 # http://www.pydocstyle.org/en/latest/error_codes.html
@@ -25,10 +25,10 @@ extend-select = B9, W504
 ignore = D105, E203, E501, W503
 per-file-ignores =
 
-# More asorted googness.
+# More assorted goodness.
 max-line-length = 120
 show-source = true
 
-# Ensure that flake8 warnings are silenced correctly.
+# Ensure that Flake8 warnings are silenced correctly.
 # https://github.com/plinss/flake8-noqa#options
 noqa-require-code = true

--- a/.flake8
+++ b/.flake8
@@ -43,3 +43,10 @@ noqa-require-code = true
 rst-roles = class, func, ref
 rst-directives = envvar, exception
 rst-substitutions = version
+
+# Ensure that Sphinx docstrings use Numpy format for docstrings:
+# https://github.com/PyCQA/flake8-docstrings
+#
+# For details on the Numpy format:
+# https://www.sphinx-doc.org/en/master/usage/extensions/example_numpy.html
+docstring-convention = numpy

--- a/.flake8
+++ b/.flake8
@@ -1,18 +1,33 @@
 # Unfortunately, flake8 does not support pyproject.toml configuration.
 # https://github.com/PyCQA/flake8/issues/234
 #
-# Disabling the following noise:
-# D105: Missing docstring in magic method
-# E501: line too long, managed better by Bugbear's B950
+# More details regarding Flake8 and Black interplay:
+# https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#flake8
 [flake8]
-ignore = D105, E501
-per-file-ignores =
-max-line-length = 120
-show-source = true
 
 # Enable Bugbear's extended opinionated checks.
 # https://github.com/PyCQA/flake8-bugbear#how-to-enable-opinionated-warnings
-extend-select = B9
+#
+# Enable W504: line break after binary operator (Black compliant)
+# https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+extend-select = B9, W504
+
+# Disabling several warnings that don't play nice with PEP8 or Black,
+# or that are a bit of a nuisance in general.
+#
+# http://www.pydocstyle.org/en/latest/error_codes.html
+# D105: Missing docstring in magic method
+#
+# https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+# E203: whitespace before ‘,’, ‘;’, or ‘:’ (not Black compliant)
+# E501: line too long, managed better by Bugbear's B950
+# W503: line break before binary operator (not Black compliant)
+ignore = D105, E203, E501, W503
+per-file-ignores =
+
+# More asorted googness.
+max-line-length = 120
+show-source = true
 
 # Ensure that flake8 warnings are silenced correctly.
 # https://github.com/plinss/flake8-noqa#options


### PR DESCRIPTION
There’s much discussion on how to make Black and Flake8 play nice with each other. There’s also much discussion on how well Flake8 implements [PEP8](https://peps.python.org/pep-0008/).

First, we’ve been using the [`ignore`](https://flake8.pycqa.org/en/6.0.0/user/options.html#cmdoption-flake8-ignore) option

https://github.com/jenstroeger/python-package-template/blob/0b40f48f607bf1a69b8f4963dea3105ee0f3bf93/.flake8#L8

which defaults to `E121,E123,E126,E226,E24,E704,W503,W504`. By providing our own we essentially re-_enabled_ these other options. Then there is [`extend-ignore`](https://flake8.pycqa.org/en/6.0.0/user/options.html#cmdoption-flake8-extend-ignore) which _extends_ to default list, rather than replacing it.

Second, considering the [Using _Black_ with other tools](https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#flake8) chapter, it proposes using
```ini
[flake8]
extend-ignore = E203
```
rather than the `ignore` option.

Perhaps we should consider following that pattern and keep Flake8’s defaults enabled? We already use only the [`extend-select`](https://flake8.pycqa.org/en/6.0.0/user/options.html#cmdoption-flake8-extend-select) option which extends the [`select`](https://flake8.pycqa.org/en/6.0.0/user/options.html#cmdoption-flake8-select) defaults `E,F,W,C90`.

<hr>

Then there is the particular question of handling the Flake8 warnings `E203: whitespace before ‘,’, ‘;’, or ‘:’` and `W503: line break before binary operator`. Both seem to disagree with PEP8 and both are triggered by Black; see also [Why are Flake8’s E203 and W503 violated?](https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated) and issue https://github.com/PyCQA/pycodestyle/issues/373.

This change disabled both warnings, and it enables `W504: line break after binary operator` which is [recommended](https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated) by Black and PEP8 compliant.