### PR TITLE
chore: disable pylint’s Similarities checker because of its noise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ fail-under = 10.0
 disable = [
     "fixme",
     "line-too-long",  # Replaced by Flake8 Bugbear B950 check.
+    "similarities",
     "too-few-public-methods",
     "too-many-ancestors",
     "too-many-arguments",


### PR DESCRIPTION
I wanted to disable `pylint`’s [Similarities](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#similarities-checker) because it’s been quite noisy with false positives in other projects where it’s always disabled too. Might as well disable it upstream here in our template?