### PR TITLE
fix(ci): add docs/source/ folder to the excludes of the Sync Upstream workflow

### DIFF
--- a/.github/workflows/sync-with-upstream.yaml
+++ b/.github/workflows/sync-with-upstream.yaml
@@ -55,7 +55,7 @@ jobs:
         else
 
           # Copy the files from the template to the current repo.
-          rsync --recursive --verbose --verbose --exclude tests/ --exclude src/ \
+          rsync --recursive --verbose --verbose --exclude tests/ --exclude src/ --exclude docs/source/ \
             --exclude .git/ --exclude .github/workflows/.template_version template/ repo/
 
           # Check if the branch exists in the current repo.


### PR DESCRIPTION
Considering we have the previous version of the template:

https://github.com/jenstroeger/python-package-template/blob/6b337a397b37d47e26f9b2889882e6e996b8aa9d/.github/workflows/sync-with-upstream.yaml#L49-L50

would it make sense to check if a branch for that previous version exists, and close the PR and delete that now older branch? Or, if not, mark the older PR as [a duplicate of the new PR](https://docs.github.com/en/issues/tracking-your-work-with-issues/marking-issues-or-pull-requests-as-a-duplicate)?

The new branch that’s being opened should include all changes from that older branch 🤔

Also, should we add [`--reviewer`](https://cli.github.com/manual/gh_pr_create#options) to the PR creation?