### PR TITLE
fix(ci): ensure correct epoch for packaged files to enable reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,9 @@ test:
 .PHONY: dist
 dist: dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-html.zip dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-md.zip dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
 dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl: check test
-	flit build --setup-py --format wheel
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) flit build --setup-py --format wheel
 dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz: check test
-	flit build --setup-py --format sdist
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) flit build --setup-py --format sdist
 dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-html.zip: docs-html
 	python -m zipfile -c dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-html.zip docs/_build/html/
 dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-md.zip: docs-md


### PR DESCRIPTION
Fixes #484 

We still have a problem which might not really be one: timezones. When we pass the [`SOURCE_DATE_EPOCH`](https://flit.pypa.io/en/stable/reproducible.html) environment variable then its value is an [epoch](https://en.wikipedia.org/wiki/Unix_time) which, by definition, is in UTC. However, `flit` sets the package files’ date to _that_ value without accounting for the timezone of the host. For example, with a timestamp of `1677448329` (26. Feb 2023 9:52:09 PM UTC, or 27 Feb 2023 7:52:09 AM AEST) the packaged files receive the following date:
```
> ll package/
total 16K
-rw-r--r-- 1 savage admin 385 Feb 26 21:52 __init__.py
-rw-r--r-- 1 savage admin 496 Feb 26 21:52 __main__.py
-rw-r--r-- 1 savage admin  80 Feb 26 21:52 py.typed
-rw-r--r-- 1 savage admin 268 Feb 26 21:52 something.py
```
on my host with AEST, where I would have expected the adjusted AEST date which was the actual packaging date 🤔

There’s currently no open issue for `flit` to discuss this.