### PR TITLE
fix(test): make pytest a little more verbose when tests fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ max-line-length = 120
 # https://docs.pytest.org/en/latest/reference/reference.html#command-line-flags
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "--verbose --doctest-modules --tb native --hypothesis-show-statistics --hypothesis-explain --hypothesis-verbosity verbose -ra --cov package"  # Consider adding --pdb
+addopts = "-vv --doctest-modules --tb native --hypothesis-show-statistics --hypothesis-explain --hypothesis-verbosity verbose -ra --cov package"  # Consider adding --pdb
 doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"
 testpaths = [
     "tests",


### PR DESCRIPTION
I didn’t find a long option version for `-vv` — `--verbose --verbose` didn’t work and neither did changing the argument to `--verbosity` (although I would have thought so from the [`pytest` arg parsing](https://github.com/pytest-dev/pytest/blob/310b67b2271cb05f575054c1cdd2ece2412c89a2/src/_pytest/terminal.py#L116-L152) or [the docs](https://docs.pytest.org/en/7.1.x/how-to/output.html#verbosity)).