### PR TITLE
feat: add actionlint hook and fix current errors

### DIFF
--- a/.github/workflows/_wiki-documentation.yaml
+++ b/.github/workflows/_wiki-documentation.yaml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   publish-wiki:
     name: Publish Github Wiki
-    if: github.repository.has_wiki == true
+    if: github.event.repository.has_wiki == true
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/sync-with-upstream.yaml
+++ b/.github/workflows/sync-with-upstream.yaml
@@ -50,7 +50,7 @@ jobs:
           && cat repo/.github/workflows/.template_version || echo "v0.0.0")
         echo "Latest version is $LATEST_VERSION and current version is $CURRENT_VERSION."
 
-        if [ $CURRENT_VERSION == $LATEST_VERSION ]; then
+        if [ "$CURRENT_VERSION" == "$LATEST_VERSION" ]; then
           echo "Unable to find a new version, exiting..."
         else
 
@@ -59,23 +59,23 @@ jobs:
             --exclude .git/ --exclude .github/workflows/.template_version template/ repo/
 
           # Check if the branch exists in the current repo.
-          cd repo/
-          if [ $(git rev-parse --verify origin/sync-$LATEST_VERSION 2>/dev/null) ]; then
+          cd repo/ || exit 1
+          if [ "$(git rev-parse --verify origin/sync-"""$LATEST_VERSION""" 2>/dev/null)" ]; then
             echo "Branch sync-$LATEST_VERSION already exists. Exiting..."
             exit 0
           fi
 
           # Create a branch, commit, and push the changeset.
-          git checkout -b sync-$LATEST_VERSION
-          echo $LATEST_VERSION > .github/workflows/.template_version
+          git checkout -b sync-"$LATEST_VERSION"
+          echo "$LATEST_VERSION" > .github/workflows/.template_version
           git add .
-          git config --global user.name $USER_NAME
-          git config --global user.email $USER_EMAIL
+          git config --global user.name "$USER_NAME"
+          git config --global user.email "$USER_EMAIL"
           git config --list --global # For debug purposes.
           git commit -m "chore: sync with template"
-          git push --set-upstream origin sync-$LATEST_VERSION
+          git push --set-upstream origin sync-"$LATEST_VERSION"
 
           # Create the pull request.
           gh pr create --base main --title "chore: sync with package template $LATEST_VERSION" \
-            --body "This PR was automatically generated." --head sync-$LATEST_VERSION
+            --body "This PR was automatically generated." --head sync-"$LATEST_VERSION"
         fi

--- a/.github/workflows/sync-with-upstream.yaml
+++ b/.github/workflows/sync-with-upstream.yaml
@@ -58,7 +58,7 @@ jobs:
           rsync --recursive --verbose --verbose --exclude tests/ --exclude src/ \
             --exclude .git/ --exclude .github/workflows/.template_version template/ repo/
 
-          cd repo/ || (echo "Unable to find the cloned repository. Exiting..." && exit 1)
+          cd repo
 
           # Check if the branch exists in the current repo.
           if [ "$(git rev-parse --verify origin/sync-"""$LATEST_VERSION""" 2>/dev/null)" ]; then

--- a/.github/workflows/sync-with-upstream.yaml
+++ b/.github/workflows/sync-with-upstream.yaml
@@ -58,8 +58,9 @@ jobs:
           rsync --recursive --verbose --verbose --exclude tests/ --exclude src/ \
             --exclude .git/ --exclude .github/workflows/.template_version template/ repo/
 
+          cd repo/ || (echo "Unable to find the cloned repository. Exiting..." && exit 1)
+
           # Check if the branch exists in the current repo.
-          cd repo/ || exit 1
           if [ "$(git rev-parse --verify origin/sync-"""$LATEST_VERSION""" 2>/dev/null)" ]; then
             echo "Branch sync-$LATEST_VERSION already exists. Exiting..."
             exit 0
@@ -72,7 +73,7 @@ jobs:
           git config --global user.name "$USER_NAME"
           git config --global user.email "$USER_EMAIL"
           git config --list --global # For debug purposes.
-          git commit -m "chore: sync with template"
+          git commit --message "chore: sync with template"
           git push --set-upstream origin sync-"$LATEST_VERSION"
 
           # Create the pull request.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,12 @@ repos:
   # - id: pretty-format-toml
   #   args: [--autofix]
 
+# Check GitHub Actions workflow files.
+- repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+  rev: v1.6.24
+  hooks:
+  - id: actionlint
+
 # On push to the remote, run the unit tests.
 - repo: local
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ audit:
 
 # Run some or all checks over the package code base.
 .PHONY: check check-code check-bandit check-flake8 check-lint check-mypy
-check-code: check-bandit check-flake8 check-lint check-mypy
+check-code: check-bandit check-flake8 check-lint check-mypy check-actionlint
 check-bandit:
 	pre-commit run bandit --all-files
 check-flake8:
@@ -160,6 +160,8 @@ check-lint:
 	pre-commit run pylint --all-files
 check-mypy:
 	pre-commit run mypy --all-files
+check-actionlint:
+	pre-commit run actionlint --all-files
 check:
 	pre-commit run --all-files
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Using the pre-commit tool and its `.pre-commit-config.yaml` configuration, the f
 - When committing code, a number of [pre-commit hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_committing_workflow_hooks) ensure that your code is formatted according to [PEP 8](https://www.python.org/dev/peps/pep-0008/) using the [`black`](https://github.com/psf/black) tool, and they’ll invoke [`flake8`](https://github.com/PyCQA/flake8) (and various plugins), [`pylint`](https://github.com/PyCQA/pylint) and [`mypy`](https://github.com/python/mypy) to check for lint and correct types. There are more checks, but those two are the important ones. You can adjust the settings for these tools in the `pyproject.toml` or `.flake8` configuration files.
 - The [commit message hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_committing_workflow_hooks) enforces [conventional commit messages](https://www.conventionalcommits.org/) and that, in turn, enables a _semantic release_ of this package on the Github side: upon merging changes into the `main` branch, the [release action](https://github.com/jenstroeger/python-package-template/blob/main/.github/workflows/release.yaml) uses the [Commitizen tool](https://commitizen-tools.github.io/commitizen/) to produce a [changelog](https://en.wikipedia.org/wiki/Changelog) and it computes the next version of this package and publishes a release — all based on the commit messages of a release.
 - Using a [pre-push hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_other_client_hooks) this package is also set up to run [`pytest`](https://github.com/pytest-dev/pytest); in addition, the [`coverage`](https://github.com/nedbat/coveragepy) plugin makes sure that _all_ of your package’s code is covered by tests and [Hypothesis](https://hypothesis.works/) is already installed to help with generating test payloads.
+- The [`actionlint`](https://github.com/Mateusz-Grzelinski/actionlint-py) hook is set up to lint GitHub Actions workflows. If [`shellcheck`](https://github.com/koalaman/shellcheck) is installed on the system, `actionlint` runs `shellcheck` to lint the `run` steps in GitHub Actions. Note that `shellcheck` is available on [Ubuntu GitHub Actions runners](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) by default.
 
 You can also run these hooks manually, which comes in very handy during daily development tasks. For example
 
@@ -150,13 +151,13 @@ You can also run these hooks manually, which comes in very handy during daily de
 make check-code
 ```
 
-runs all the code checks (i.e. `bandit`, `flake8`, `pylint` and `mypy`), whereas
+runs all the code checks (i.e. `bandit`, `flake8`, `pylint`, `mypy`, `actionlint`), whereas
 
 ```bash
 make check
 ```
 
-runs _all_ installed git hooks over your code. For more control over the code checks, the Makefile also implements the `check-bandit`, `check-flake8`, `check-lint`, and `check-mypy` goals.
+runs _all_ installed git hooks over your code. For more control over the code checks, the Makefile also implements the `check-bandit`, `check-flake8`, `check-lint`, `check-mypy`, and `check-actionlint` goals.
 
 ## Testing
 


### PR DESCRIPTION
This PR adds [actionlint](https://github.com/Mateusz-Grzelinski/actionlint-py) as a pre-commit hook to lint and check GitHub Actions workflows. The check runs using `make check-actionlint`. 

The new `actionlint` hook detects errors that were also addressed in https://github.com/jenstroeger/python-package-template/pull/482 and https://github.com/jenstroeger/python-package-template/pull/493, which had to be fixed here for the workflows to succeed.