### PR TITLE
fix(deps): temporarily pin typing-extensions deps, to avoid breaking the sphinxnotes-markdown-builder package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
 docs = [
     "sphinx >=5.1.1,<8.0.0",
     "sphinxnotes-markdown-builder >=0.5.6,<1.0.0",
+    "typing-extensions <4.6.0",  # markdown-builder uses pydash: https://github.com/dgilland/pydash/issues/197
 ]
 hooks = [
     "pre-commit >=2.18.0,<3.4.0",


### PR DESCRIPTION
See also https://github.com/dgilland/pydash/issues/197