### PR TITLE
feat: treat Sphinx docs warnings as errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,9 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+
+# Treat the warnings as errors.
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build


### PR DESCRIPTION
This PR changes the Sphinx configuration to treat warnings as errors, which helps to detect documentation issues in CI tests.