### PR TITLE
fix: change git hook to check for large files on commit, instead of push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,8 @@ repos:
   - id: check-case-conflict
   - id: check-merge-conflict
   - id: check-added-large-files
+    stages: [commit]
+    args: [--maxkb=500]
   - id: debug-statements
   - id: end-of-file-fixer
     stages: [commit]


### PR DESCRIPTION
Note that the arg of 500kb is the [default](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#check-added-large-files) that I added for documentation’s sake.