### PR TITLE
feat: use yamllint to check YAML files, instead of simply parsing and pretty-printing them

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start rule:document-end
+
 name: CodeQL configuration
 paths:
 - src/package

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,8 @@
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
 # https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories
 # https://github.com/dependabot/feedback/issues/551
+#
+# yamllint disable rule:document-start rule:document-end
 
 version: 2
 updates:

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -18,9 +18,11 @@
 # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
 #
 # for the security recommendations.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Build the package
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       disable-pip-audit:

--- a/.github/workflows/_generate-rebase.yaml
+++ b/.github/workflows/_generate-rebase.yaml
@@ -1,8 +1,10 @@
 # Automatically rebase one branch on top of another; usually main on top
 # of release after a new package version was published.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Rebase branch
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       to-head:

--- a/.github/workflows/_release-notifications.yaml
+++ b/.github/workflows/_release-notifications.yaml
@@ -1,8 +1,10 @@
 # Send a Slack release notification. Instructions to set up Slack to receive
 # messages can be found here: https://github.com/slackapi/slack-github-action#setup-2
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Release Notifications
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       repo-name:

--- a/.github/workflows/_wiki-documentation.yaml
+++ b/.github/workflows/_wiki-documentation.yaml
@@ -1,9 +1,11 @@
 # This reusable workflow publishes Markdown docs to Github Wiki. Some manual
 # setup is required before using it: enable Wiki in repository and create at
 # least one page.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Publish Github Wiki documentation
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       release-tag:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,8 +1,10 @@
 # Run CodeQL over the package. For more configuration options see codeql/codeql-config.yaml
 # and: https://github.com/github/codeql-action
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: CodeQL
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
     - release

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,8 +1,10 @@
 # Automatically merge Dependabot PRs upon approval.
 # https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Automerge Dependabot PR
-on:
+on: # yamllint disable-line rule:truthy
   pull_request_review:
     types: [submitted]
 

--- a/.github/workflows/pr-change-set.yaml
+++ b/.github/workflows/pr-change-set.yaml
@@ -1,8 +1,10 @@
 # This workflow checks and tests the package code, and it builds all package
 # artifacts whenever there were changes to a pull request.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Check change set
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -2,9 +2,11 @@
 # package (https://github.com/commitizen-tools/commitizen) and its `cz`
 # tool to check the title of the PR and all commit messages of the branch
 # which triggers this Action.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Check conventional commits
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,10 @@
 # We run checks on pushing to the specified branches.
 # Pushing to release also triggers a release.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Check and Release
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
     - release

--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -1,7 +1,9 @@
 # Run Scorecard for this repository to further check and harden software and process.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Scorecards supply-chain security
-on:
+on: # yamllint disable-line rule:truthy
   # Only the default branch is supported.
   branch_protection_rule:
   schedule:

--- a/.github/workflows/sync-with-upstream.yaml
+++ b/.github/workflows/sync-with-upstream.yaml
@@ -1,8 +1,10 @@
 # Create a PR to sync with the upstream template repo.
 # The template repo is https://github.com/jenstroeger/python-package-template.
+#
+# yamllint disable rule:document-start rule:document-end
 
 name: Sync with template repository
-on:
+on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 
   schedule:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# yamllint disable rule:document-start rule:document-end
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_install_hook_types: [pre-commit, commit-msg, pre-push]
@@ -120,7 +122,6 @@ repos:
   - id: detect-private-key
   - id: detect-aws-credentials
     args: [--allow-missing-credentials]
-  - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # frozen: v1.10.0
@@ -150,15 +151,23 @@ repos:
     args: [--autofix]
   - id: pretty-format-yaml
     args: [--autofix]
-  # Commenting this out because https://github.com/pappasam/toml-sort/issues/11
-  # - id: pretty-format-toml
-  #   args: [--autofix]
+    # Commenting this out because https://github.com/pappasam/toml-sort/issues/11
+    # - id: pretty-format-toml
+    #   args: [--autofix]
 
 # Check GitHub Actions workflow files.
 - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
   rev: c04ed26e40637cab1aa9879c693832a9c120fb20  # frozen: v1.7.12.24
   hooks:
   - id: actionlint
+
+# Check and lint all YAML files.
+# https://yamllint.readthedocs.io/en/stable/rules.html
+- repo: https://github.com/adrienverge/yamllint
+  rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
+  hooks:
+  - id: yamllint
+    args: [--strict]
 
 # On push to the remote, run all tests.
 - repo: local

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,15 @@
+# Modify yamllint's defaults so that they work well and strictly with
+# ruamel's pretty-formatting of the YAML files.
+#
+# For more details: https://yamllint.readthedocs.io/en/stable/rules.html
+#
+# yamllint disable rule:document-start rule:document-end
+
+extends: default
+rules:
+  line-length:
+    max: 512
+  indentation:
+    indent-sequences: consistent
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
There are differences between [YAML 1.1](https://yaml.org/spec/1.1/) and [YAML 1.2](https://yaml.org/spec/1.2.2/), and out there in the wild different tools use different YAML parsers for either version of YAML files.

Currently, we use https://github.com/jenstroeger/python-package-template/blob/40e438b0adab9e4d90f754811bba7a1284d592d9/.pre-commit-config.yaml#L120 and https://github.com/jenstroeger/python-package-template/blob/40e438b0adab9e4d90f754811bba7a1284d592d9/.pre-commit-config.yaml#L148-L149 to check and pretty-print YAML files, both of which use the [ruamel](https://github.com/pycontribs/ruamel-yaml) package which defaults to parsing and interpreting YAML 1.2 files ([more details](https://yaml.readthedocs.io/en/latest/detail/#document-version-support)).

However — and that’s where trouble starts, and that’s what happened in a dependent repo — by pretty-printing the YAML files using a YAML 1.2 parser we turn a
```yaml
- args:
  - --option
  - "on"
```
sequence into
```yaml
- args:
  - --option
  - on
```
which is valid YAML 1.2 but creates problems with YAML 1.1 parsers: there, the scalar `on` is interpreted as a boolean value ([docs](https://yaml.org/type/bool.html)) and turned into `true`, thus breaking the `args` sequence.

Adding this YAML linter actually prevents that breakage because the linter notes a violation of its [truthy rule](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy).

<hr>

I’d like to tinker a little more here: for example, handling of multiple documents `---` in a single file seems inconsistent between ruamel and yamllint, and it would be helpful to disable line-length checking ([docs](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.line_length)) without using other options. Also, see issue https://github.com/adrienverge/yamllint/issues/632.