### PR TITLE
fix(deps-dev): revert artifact download and upload GitHub Actions to v3

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -134,7 +134,7 @@ jobs:
     # Currently reusable workflows do not support setting strategy property from the caller workflow.
     - name: Upload the package artifact for debugging and release
       if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: artifact-${{ matrix.os }}-python-${{ matrix.python }}
         path: dist

--- a/.github/workflows/_wiki-documentation.yaml
+++ b/.github/workflows/_wiki-documentation.yaml
@@ -57,7 +57,7 @@ jobs:
 
     # Download the build artifacts attached to this workflow run.
     - name: Download artifact
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: ${{ inputs.artifact-name }}
         path: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,7 +107,7 @@ jobs:
         fetch-depth: 0
 
     - name: Download artifact
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: artifact-ubuntu-latest-python-3.11
         path: dist
@@ -207,8 +207,10 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Important: update actions/download-artifact to v4 only when generator_generic_slsa3.yml is also compatible.
+    # See https://github.com/slsa-framework/slsa-github-generator/issues/3068
     - name: Download provenance
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: ${{ needs.provenance.outputs.provenance-name }}
 

--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -52,7 +52,7 @@ jobs:
 
     # Upload the results as artifacts (optional).
     - name: Upload artifact
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: SARIF file
         path: results.sarif


### PR DESCRIPTION
The provenance generator GitHub Action [generator_generic_slsa3.yml](https://github.com/jenstroeger/python-package-template/blob/92b86565b015e5b36e18adcea21b0c41c4997ce5/.github/workflows/release.yaml#L178) is not compatible with `actions/download-artifact@v4` yet. We need to make sure these two Actions and `actions/upload-artifact` are all compatible.

This PR reverts `actions/download-artifact` and  `actions/upload-artifact` GitHub Actions to v3. We will update them to v4 when the next version of generator_generic_slsa3.yml that will be compatible with `actions/download-artifact@v4` is released. See this relevant https://github.com/slsa-framework/slsa-github-generator/issues/3068.