### PR TITLE
fix(ci): use actions/upload-artifact@v4 to be compatible with slsa provenance action

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -134,7 +134,7 @@ jobs:
     # Currently reusable workflows do not support setting strategy property from the caller workflow.
     - name: Upload the package artifact for debugging and release
       if: matrix.os == env.ARTIFACT_OS && matrix.python == env.ARTIFACT_PYTHON
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: artifact-${{ matrix.os }}-python-${{ matrix.python }}
         path: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -207,8 +207,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Important: update actions/download-artifact to v4 only when generator_generic_slsa3.yml is also compatible.
-    # See https://github.com/slsa-framework/slsa-github-generator/issues/3068
     - name: Download provenance
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d # v4.1.5
       with:

--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -52,7 +52,7 @@ jobs:
 
     # Upload the results as artifacts (optional).
     - name: Upload artifact
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: SARIF file
         path: results.sarif


### PR DESCRIPTION
The `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0` GitHub Action requires `actions/upload-artifact@v4` Action. See the [CHANGELOG](https://github.com/slsa-framework/slsa-github-generator/blob/v2.0.0/CHANGELOG.md#v200-breaking-change-upload-artifact-and-download-artifact) for more information.