### PR TITLE
fix(ci): also update setuptools when setting up the virtual environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ setup: force-upgrade
 .PHONY: upgrade force-upgrade
 upgrade: .venv/upgraded-on
 .venv/upgraded-on: pyproject.toml
-	python -m pip install --upgrade pip
+	python -m pip install --upgrade pip setuptools
 	python -m pip install --upgrade wheel
 	python -m pip install --upgrade --upgrade-strategy eager --editable .[actions,dev,docs,hooks,test]
 	$(MAKE) upgrade-quiet


### PR DESCRIPTION
So, here’s the thing. Python 3.10.14 and 3.11.9 create a venv like so[^1]
```
~ > python3.10 -m venv test
~ > . test/bin/activate
(test) ~ > pip list
Package    Version
---------- -------
pip        23.0.1
setuptools 65.5.0
```
The problem is that setuptools v65.5.0 and below are subject to https://github.com/advisories/GHSA-r9hx-vwmv-q579, and should be — like pip — updated to the latest version when we set up the venv. If not, there’s a good chance that `make audit` will trigger if no other package happens to update the setuptools package…

In this package we’ve been lucky because of an indirect dependency (e.g. [here](https://github.com/jenstroeger/python-package-template/actions/runs/10556221766/job/29241332587?pr=789#step:7:100)) and our [eager update strategy](https://pip.pypa.io/en/stable/development/architecture/upgrade-options/#controlling-what-gets-installed):
```
Collecting setuptools>=30.3.0 (from pytest-doctestplus==1.2.1->package==2.13.3)
  Downloading setuptools-72.1.0-py3-none-any.whl.metadata (6.6 kB)
```
Other packages/repos derived from this one, however, have their own dependencies and did _not_ update setuptools (anymore) and, thus, the package audit triggered and failed CI.

[^1]: Python 3.12 does not install setuptools by default.