### PR TITLE
feat: add support for Python 3.13

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -6,7 +6,7 @@
 #
 # Even though we run the build in a matrix to check against different platforms, due to a known
 # limitation of reusable workflows that do not support setting strategy property from the caller
-# workflow, we only generate artifacts for ubuntu-latest and Python 3.12, which can be used to
+# workflow, we only generate artifacts for ubuntu-latest and Python 3.13, which can be used to
 # create a release. For details see:
 #
 # https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
@@ -35,7 +35,7 @@ permissions:
   contents: read
 env:
   ARTIFACT_OS: ubuntu-latest # The default OS for release.
-  ARTIFACT_PYTHON: '3.12' # The default Python version for release.
+  ARTIFACT_PYTHON: '3.13' # The default Python version for release.
 
 jobs:
   build:
@@ -51,7 +51,7 @@ jobs:
         # It is recommended to pin a Runner version specifically:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13']
     steps:
 
     - name: Harden Runner

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -33,7 +33,7 @@ jobs:
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
         language: [python]
-        python: ['3.12']
+        python: ['3.13']
     steps:
 
     - name: Harden Runner

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     # Install Commitizen without using the package's Makefile: that's much faster than
     # creating a venv and installing heaps of dependencies that aren't required for this job.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Set up Commitizen
       run: |
@@ -111,7 +111,7 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        name: artifact-ubuntu-latest-python-3.12
+        name: artifact-ubuntu-latest-python-3.13
         path: dist
 
     # Verify hashes by first computing hashes for the artifacts and then comparing them
@@ -128,7 +128,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Set up Commitizen
       run: |
@@ -250,7 +250,7 @@ jobs:
       # Github disallows passing environment variables as arguments to a reusable
       # workflow, so we have to duplicate these values here. Related discussion
       # here: https://github.com/actions/toolkit/issues/931
-      artifact-name: artifact-ubuntu-latest-python-3.12
+      artifact-name: artifact-ubuntu-latest-python-3.13
       git-user-name: jenstroeger
       git-user-email: jenstroeger@users.noreply.github.com
     secrets:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 .PHONY: all
 all: check test dist docs
 
-# Create a virtual environment, either for Python3.12 (default) or using
+# Create a virtual environment, either for Python3.13 (default) or using
 # the Python interpreter specified in the PYTHON environment variable. Also
 # create an empty pip.conf file to ensure that `pip config` modifies this
 # venv only, unless told otherwise. For more background, see:
@@ -70,8 +70,8 @@ venv:
 	  echo "Found an inactive Python virtual environment, please activate or nuke it" && exit 1; \
 	fi
 	if [ -z "${PYTHON}" ]; then \
-	  echo "Creating virtual environment in .venv/ for python3.12"; \
-	  python3.12 -m venv --upgrade-deps --prompt . .venv; \
+	  echo "Creating virtual environment in .venv/ for python3.13"; \
+	  python3.13 -m venv --upgrade-deps --prompt . .venv; \
 	else \
 	  echo "Creating virtual environment in .venv/ for ${PYTHON}"; \
 	  ${PYTHON} -m venv --upgrade-deps --prompt . .venv; \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The badges above give you an idea of what this project template provides. It’s
 
 ### Typing
 
-The package requires a minimum of [Python 3.10](https://www.python.org/downloads/release/python-31014/), and it supports [Python 3.11](https://www.python.org/downloads/release/python-3118/) and [Python 3.12](https://www.python.org/downloads/release/python-3121/) (default). All code requires comprehensive [typing](https://docs.python.org/3/library/typing.html). The [mypy](http://mypy-lang.org/) static type checker and the [flake8-pyi](https://github.com/PyCQA/flake8-pyi) plugin are invoked by git hooks and through a Github Action to enforce continuous type checks on Python source and [stub files](https://peps.python.org/pep-0484/#stub-files). Make sure to add type hints to your code or to use [stub files](https://mypy.readthedocs.io/en/stable/stubs.html) for types, to ensure that users of your package can `import` and type-check your code (see also [PEP 561](https://www.python.org/dev/peps/pep-0561/)).
+The package requires a minimum of [Python 3.10](https://www.python.org/downloads/release/python-31015/), and it supports [Python 3.11](https://www.python.org/downloads/release/python-31110/), [Python 3.12](https://www.python.org/downloads/release/python-3127/) and [Python 3.13](https://www.python.org/downloads/release/python-3130/) (default). All code requires comprehensive [typing](https://docs.python.org/3/library/typing.html). The [mypy](http://mypy-lang.org/) static type checker and the [flake8-pyi](https://github.com/PyCQA/flake8-pyi) plugin are invoked by git hooks and through a Github Action to enforce continuous type checks on Python source and [stub files](https://peps.python.org/pep-0484/#stub-files). Make sure to add type hints to your code or to use [stub files](https://mypy.readthedocs.io/en/stable/stubs.html) for types, to ensure that users of your package can `import` and type-check your code (see also [PEP 561](https://www.python.org/dev/peps/pep-0561/)).
 
 ### Quality assurance
 
@@ -99,19 +99,19 @@ If you’d like to start your own Python project from scratch, you can either co
 To develop your new package, first create a [virtual environment](https://docs.python.org/3/tutorial/venv.html) by either using the [Makefile](https://www.gnu.org/software/make/manual/make.html#toc-An-Introduction-to-Makefiles):
 
 ```bash
-make venv  # Create a new virtual environment in .venv folder using Python 3.10.
+make venv  # Create a new virtual environment in .venv folder using Python 3.13.
 ```
 
 or for a specific version of Python:
 
 ```bash
-PYTHON=python3.10 make venv  # Same virtual environment for a different Python version.
+PYTHON=python3.12 make venv  # Same virtual environment for a different Python version.
 ```
 
 or manually:
 
 ```bash
-python3.12 -m venv .venv  # Or use .venv312 for more than one local virtual environments.
+python3.13 -m venv .venv  # Or use .venv313 for more than one local virtual environments.
 ```
 
 When working with this Makefile _it is important to always [activate the virtual environment](https://docs.python.org/3/library/venv.html)_ because some of the [git hooks](#git-hooks) (see below) depend on that:
@@ -171,45 +171,42 @@ Both statement and branch coverage are being tracked using [coverage](https://gi
 ```
 Run unit tests...........................................................Passed
 - hook id: pytest
-- duration: 0.6s
+- duration: 1.74s
 
 ============================= test session starts ==============================
-platform darwin -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0 -- /path/to/python-package-template/.venv/bin/python
+platform darwin -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0 -- /path/to/python-package-template/.venv/bin/python
 cachedir: .pytest_cache
-hypothesis profile 'default-with-verbose-verbosity-with-explain-phase' -> max_examples=500, verbosity=Verbosity.verbose, phases=(Phase.explicit, Phase.reuse, Phase.generate, Phase.target, Phase.shrink, Phase.explain), database=DirectoryBasedExampleDatabase('/path/to/python-package-template/.hypothesis/examples')
+hypothesis profile 'default-with-verbose-verbosity' -> max_examples=500, verbosity=Verbosity.verbose, database=DirectoryBasedExampleDatabase(PosixPath('/path/to/python-package-template/.hypothesis/examples'))
 rootdir: /path/to/python-package-template
 configfile: pyproject.toml
-plugins: custom-exit-code-0.3.0, cov-4.1.0, doctestplus-1.1.0, hypothesis-6.90.0, env-1.1.1
+plugins: cov-5.0.0, hypothesis-6.111.2, env-1.1.3, custom-exit-code-0.3.0, doctestplus-1.2.1
 collected 3 items
 
 src/package/something.py::package.something.Something.do_something PASSED [ 33%]
-tests/test_something.py::test_something PASSED                            [ 66%]
-docs/source/index.rst::index.rst PASSED                                   [100%]
+tests/test_something.py::test_something PASSED                           [ 66%]
+docs/source/index.rst::index.rst PASSED                                  [100%]
 
----------- coverage: platform darwin, python 3.11.7-final-0 ----------
+---------- coverage: platform darwin, python 3.13.0-final-0 ----------
 Name                       Stmts   Miss Branch BrPart  Cover   Missing
 ----------------------------------------------------------------------
 src/package/__init__.py        1      0      0      0   100%
-src/package/something.py       4      0      2      0   100%
+src/package/something.py       4      0      0      0   100%
 ----------------------------------------------------------------------
-TOTAL                          5      0      2      0   100%
+TOTAL                          5      0      0      0   100%
 
 Required test coverage of 100.0% reached. Total coverage: 100.00%
 ============================ Hypothesis Statistics =============================
 
 tests/test_something.py::test_something:
 
-  - during reuse phase (0.00 seconds):
-    - Typical runtimes: < 1ms, of which < 1ms in data generation
-    - 1 passing examples, 0 failing examples, 0 invalid examples
-
   - during generate phase (0.00 seconds):
-    - Typical runtimes: < 1ms, of which < 1ms in data generation
-    - 1 passing examples, 0 failing examples, 0 invalid examples
+    - Typical runtimes: ~ 0-1 ms, of which < 1ms in data generation
+    - 2 passing examples, 0 failing examples, 0 invalid examples
 
   - Stopped because nothing left to do
 
-============================== 3 passed in 0.05s ===============================
+
+============================== 3 passed in 0.08s ===============================
 ```
 Note that code that’s not covered by tests is listed under the `Missing` column, and branches not taken too. The net effect of enforcing 100% code and branch coverage is that every new major and minor feature, every code change, and every fix are being tested (keeping in mind that high _coverage_ does not imply comprehensive, meaningful _test data_).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Adding support for [Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html).

@behnazh I’ve not yet dropped support for Python 3.10 because we’re using it in other projects, though I think I’m ok with moving to 3.12 as the minimal supported version because both 3.10 ([release schedule](https://peps.python.org/pep-0619/#lifespan)) and 3.11 ([release schedule](https://peps.python.org/pep-0664/#lifespan)) are now considered legacy.