### PR TITLE
feat(test): add support for TAP (Test Anything Protocol)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
     "pytest-cov ==5.0.0",
     "pytest-doctestplus ==1.2.1",
     "pytest-env ==1.1.3",
+    "pytest-tap ==3.4.0",
 ]
 
 [project.urls]
@@ -254,6 +255,7 @@ addopts = """-vv -ra --tb native \
     --doctest-modules --doctest-continue-on-failure --doctest-glob '*.rst' --doctest-plus \
     --suppress-no-test-exit-code \
     --cov package \
+    --tap \
 """  # Consider adding --pdb
 # https://docs.python.org/3/library/doctest.html#option-flags
 doctest_optionflags = "IGNORE_EXCEPTION_DETAIL"


### PR DESCRIPTION
The interesting thing about [TAP](https://testanything.org/) (Test Anything Protocol) is that test output from different sources can be consolidated and analyzed as one. This change adds a pytest plugin which generated TAP output for tests, thus enabling TAP compatible test output.