### PR TITLE
fix: don’t attempt to sort imports on `git push` (they must already be sorted)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
   - id: isort
     name: Sort import statements
     args: [--settings-path, pyproject.toml]
+    stages: [pre-commit]
 
 # Add Black code formatters.
 - repo: https://github.com/ambv/black


### PR DESCRIPTION
Turns out that the isort hook configuration [here](https://github.com/PyCQA/isort/blob/main/.pre-commit-hooks.yaml) wants to run the isort hook at different times — so we pin it down to pre-commit only.