### PR TITLE
feat(test): add the duration of tests to the printed test summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,7 +251,7 @@ max-line-length = 120
 # https://github.com/yashtodi94/pytest-custom_exit_code
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = """-vv -ra --tb native \
+addopts = """-vv -ra --tb native --durations 0 \
     --hypothesis-show-statistics --hypothesis-explain --hypothesis-verbosity verbose \
     --doctest-modules --doctest-continue-on-failure --doctest-glob '*.rst' --doctest-plus \
     --suppress-no-test-exit-code \


### PR DESCRIPTION
Documented [here](https://docs.pytest.org/en/6.2.x/usage.html#profiling-test-execution-duration) the argument `0` prints durations for all tests.