### PR TITLE
feat(test): add the pytest-cases package and a simple example of how to use it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ hooks = [
 test = [
     "hypothesis >=6.21.0,<6.122.8",
     "pytest >=7.2.0,<9.0.0",
+    "pytest-cases ==3.8.6",
     "pytest-custom_exit_code ==0.3.0",
     "pytest-cov ==6.0.0",
     "pytest-doctestplus ==1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ hooks = [
 ]
 # Note that the `custom_exit_code` and `env` plugins may currently be unmaintained.
 test = [
+    "faker ==35.0.0",
     "hypothesis >=6.21.0,<6.122.8",
     "pytest >=7.2.0,<9.0.0",
     "pytest-cases ==3.8.6",

--- a/tests/test_something.py
+++ b/tests/test_something.py
@@ -1,11 +1,18 @@
 """Test the Something module. Add more tests here, as needed."""
 
 from hypothesis import given, strategies
+from pytest_cases import parametrize
 
 from package.something import Something
 
 
 @given(strategies.booleans())
-def test_something(boolean: bool) -> None:
-    """Test something here."""
+def test_something_hypothesis(boolean: bool) -> None:
+    """Test something here using Hypothesis."""
+    assert Something.do_something(boolean) is True
+
+
+@parametrize("boolean", [True, False])
+def test_something_cases(boolean: bool) -> None:
+    """Test something here using Cases."""
     assert Something.do_something(boolean) is True

--- a/tests/test_something.py
+++ b/tests/test_something.py
@@ -1,7 +1,8 @@
 """Test the Something module. Add more tests here, as needed."""
 
+import faker
 from hypothesis import given, strategies
-from pytest_cases import parametrize
+from pytest_cases import parametrize_with_cases
 
 from package.something import Something
 
@@ -12,7 +13,12 @@ def test_something_hypothesis(boolean: bool) -> None:
     assert Something.do_something(boolean) is True
 
 
-@parametrize("boolean", [True, False])
+def _case_boolean() -> bool:
+    fake = faker.Faker()
+    return fake.pybool()
+
+
+@parametrize_with_cases("boolean", cases=_case_boolean)
 def test_something_cases(boolean: bool) -> None:
     """Test something here using Cases."""
     assert Something.do_something(boolean) is True

--- a/tests/test_something.py
+++ b/tests/test_something.py
@@ -20,5 +20,5 @@ def _case_boolean() -> bool:
 
 @parametrize_with_cases("boolean", cases=_case_boolean)
 def test_something_cases(boolean: bool) -> None:
-    """Test something here using Cases."""
+    """Test something here using Cases and Faker."""
     assert Something.do_something(boolean) is True


### PR DESCRIPTION
The [pytest-cases](https://smarie.github.io/python-pytest-cases/) plugin is very useful to separate test case generation from test function, a separation that’s not as explicit in pytest itself. I think with PR https://github.com/smarie/python-pytest-cases/issues/319 this change could offer quite flexible & powerful testing.