### PR TITLE
feat(ci): group multiple Dependabot changes into single PRs for breaking/non-breaking changes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,18 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: main
+  # Group updates into pull requests. See also:
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--
+  groups:
+    pip-breaking-changes:
+      applies-to: version-updates
+      update-types:
+      - major
+    pip-non-breaking-changes:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
   # Add additional reviewers for PRs opened by Dependabot. For more information, see:
   # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
   # reviewers:
@@ -29,6 +41,18 @@ updates:
     include: scope
   open-pull-requests-limit: 13
   target-branch: main
+  # Group updates into pull requests. See also:
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--
+  groups:
+    gh-breaking-changes:
+      applies-to: version-updates
+      update-types:
+      - major
+    gh-non-breaking-changes:
+      applies-to: version-updates
+      update-types:
+      - minor
+      - patch
   # Add additional reviewers for PRs opened by Dependabot. For more information, see:
   # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
   # reviewers:


### PR DESCRIPTION
Leaving this in Draft mode while testing and to discuss details, e.g. can we name the groups better, do we want to refine the grouping, whatnot…

See also:

- Official [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--), and
- [Grouped version updates for Dependabot public beta](https://github.blog/changelog/2023-06-29-grouped-version-updates-for-dependabot-public-beta/), and
- [Grouped version updates for Dependabot are generally available](https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/).
