### PR TITLE
feat(ci): cancel existing running workflows for a PR when a new change is pushed to that PR

### DIFF
--- a/.github/workflows/pr-change-set.yaml
+++ b/.github/workflows/pr-change-set.yaml
@@ -14,6 +14,11 @@ on:
 permissions:
   contents: read
 
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/_build.yaml


### PR DESCRIPTION
Suppose we’re working on a PR and push a change to the PR’s branch: that’ll trigger the [Check change set](https://github.com/jenstroeger/python-package-template/blob/main/.github/workflows/pr-change-set.yaml) workflow. Now, if we push multiple times in quick succession then every push will trigger that workflow and suddenly we have that workflow run concurrently multiple times — even though, technically, only the most recent push is required.

This change automatically cancels existing workflow runs (if any) upon pushing to a PR’s branch.

For more details, see [the docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency).