### PR TITLE
perf(test): use Python’s system monitoring facilities to improve performance of test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ check:
 # the hook setup itself does not pass files to pytest (see .pre-commit-config.yaml).
 .PHONY: test
 test:
-	pre-commit run pytest --hook-stage push --files tests/
+	COVERAGE_CORE=sysmon pre-commit run pytest --hook-stage push --files tests/
 
 # Build a source distribution package and a binary wheel distribution artifact.
 # When building these artifacts, we need the environment variable SOURCE_DATE_EPOCH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test = [
     "pytest >=7.2.0,<9.0.0",
     "pytest-cases ==3.8.6",
     "pytest-custom_exit_code ==0.3.0",
-    "pytest-cov ==6.1.0",
+    "pytest-cov ==6.1.1",  # Uses: coverage[toml] >=7.5
     "pytest-doctestplus ==1.3.0",
     "pytest-env ==1.1.5",
 ]


### PR DESCRIPTION
Based on the [Optimizing coverage with Python 3.12’s sys.monitoring](https://blog.trailofbits.com/2025/05/01/making-pypis-test-suite-81-faster/#optimizing-coverage-with-python-312s-sysmonitoring) blog section, this change almost doubles the performance of test runs (based on trying this change in three production repos).