### PR TITLE
feat: add a Makefile goal `simple-index` that generates a PEP-503 compatible Simple Index directory inside the dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,18 @@ dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-md.zip: docs-md
 dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt:
 	echo $(SOURCE_DATE_EPOCH) > dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
 
+# Build a PEP-503 compatible Simple Repository compatible directory inside of dist/.
+# For details on the layout of that directory, see: https://peps.python.org/pep-0503/
+# This directory can then be used to install (hashed) artifacts from using `pip` and
+# its `--extra-index-url` argument: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url
+.PHONY: simple-index
+simple-index: dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz
+	mkdir -p dist/simple-index/$(PACKAGE_NAME)
+	echo -e "<!-- https://peps.python.org/pep-0503/ -->\n<!DOCTYPE html><html><head><meta name='pypi:repository-version' content='1.3'></head><body><a href='/$(PACKAGE_NAME)/'>$(PACKAGE_NAME)</a></body></html>" > dist/simple-index/index.html
+	echo -e "<!-- https://peps.python.org/pep-0503/ -->\n<!DOCTYPE html><html><head><meta name='pypi:repository-version' content='1.3'></head><body><a href='$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl'>$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl</a><a href='$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz'>$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz</a></body></html>" > dist/simple-index/$(PACKAGE_NAME)/index.html
+	cp -f dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl dist/simple-index/$(PACKAGE_NAME)/
+	cp -f dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz dist/simple-index/$(PACKAGE_NAME)/
+
 # Build the HTML and Markdown documentation from the package's source.
 DOCS_SOURCE := $(shell git ls-files docs/source)
 .PHONY: docs docs-html docs-md


### PR DESCRIPTION
As discussed with @behnazh this changes makes available a [PEP-503](https://peps.python.org/pep-0503/) compatible Simple Repository directory inside of our dist/ directory.

We can now use `pip` and its [`--extra-index-url`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url) argument to install packages, including support for their package hashes. For example to install the binary package (pip’s default):
```
> pip install --extra-index-url file:///path/to/dist/simple-index/ package
Looking in indexes: https://pypi.org/simple, file:///path/to/dist/simple-index/
Processing /path/to/dist/simple-index/package/package-2.16.0-py3-none-any.whl
Installing collected packages: package
Successfully installed package-2.16.0
```
or the source package ([purge](https://pip.pypa.io/en/stable/cli/pip_cache/) the `pip` cache first!):
```
> pip install --extra-index-url file:///path/to/dist/simple-index/ --no-binary package package
Looking in indexes: https://pypi.org/simple, file:///path/to/dist/simple-index/
Processing /path/to/dist/simple-index/package/package-2.16.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: package
  Building wheel for package (pyproject.toml) ... done
  Created wheel for package: filename=package-2.16.0-py3-none-any.whl size=13457 sha256=9791036dfa1a658e1e43afaa41404a126f3e01b8f36ccc1f98551bbfe50c1da4
  Stored in directory: /path/to/pip/wheels/03/64/4f/969f1993221587084c494fb7687826621c9273963119358c62
Successfully built package
Installing collected packages: package
Successfully installed package-2.16.0
```
or from the generated requirements file using package hashes:
```
> pip install --extra-index-url file:///path/to/dist/simple-index/ --require-hashes --requirement package-2.16.0-requirements.txt 
Looking in indexes: https://pypi.org/simple, file:///path/to/dist/simple-index/
...
Processing /path/to/dist/simple-index/package/package-2.16.0-py3-none-any.whl (from -r package-2.16.0-requirements.txt (line 982))
```