### PR TITLE
fix: remove various repo files that leaked into the sdist of the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,15 @@ omit = [
 include = []
 exclude = [
     ".github/",
+    ".vscode/",
     "docs/",
     "tests/",
     ".flake8",
+    ".gitattributes",
     ".gitignore",
     ".pre-commit-config.yaml",
     "CHANGELOG.md",
+    "CODEOWNERS",
     "Makefile",
     "SECURITY.md",
 ]


### PR DESCRIPTION
@behnazh the sdist still contains the `pyproject.toml` file:
```
> tar tvf dist/package-2.16.0.tar.gz 
-rw-r--r-- 0/0            1063 2025-06-03 00:17 package-2.16.0/LICENSE.md
-rw-r--r-- 0/0           28836 2025-06-03 00:17 package-2.16.0/README.md
-rw-r--r-- 0/0            8257 2025-06-03 00:17 package-2.16.0/pyproject.toml
-rw-r--r-- 0/0             386 2025-06-03 00:17 package-2.16.0/src/package/__init__.py
-rw-r--r-- 0/0             496 2025-06-03 00:17 package-2.16.0/src/package/__main__.py
-rw-r--r-- 0/0              80 2025-06-03 00:17 package-2.16.0/src/package/py.typed
-rw-r--r-- 0/0             520 2025-06-03 00:17 package-2.16.0/src/package/something.py
-rw-r--r-- 0/0            1352 1970-01-01 10:00 package-2.16.0/setup.py
-rw-r--r-- 0/0           31320 1970-01-01 10:00 package-2.16.0/PKG-INFO
```
which contains all development dependencies masquerading as package extras: https://github.com/jenstroeger/python-package-template/blob/29d02e3ea709ec748399e8f590d2769fd51d5c62/pyproject.toml#L43-L72 as well as all settings for many of the development tools which are completely unrelated to the package’s sdist itself.

See issue https://github.com/jenstroeger/python-package-template/issues/951.