### PR TITLE
fix: building the package’s dist files should *always* generate the build’s epoch as well, even when using the individual package goals only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,9 +176,9 @@ test:
 # set to the build date/epoch. For more details, see: https://flit.pypa.io/en/latest/reproducible.html
 .PHONY: dist
 dist: dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-html.zip dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-md.zip dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
-dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl: check test
+dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-py3-none-any.whl: check test dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) flit build --setup-py --format wheel
-dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz: check test
+dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz: check test dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-build-epoch.txt
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) flit build --setup-py --format sdist
 dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-html.zip: docs-html
 	python -m zipfile -c dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-docs-html.zip docs/_build/html/


### PR DESCRIPTION
The issue was that we can build an artifact but we won’t have the artifact’s build epoch timestamp:
```
> make dist/package-2.16.0.tar.gz
...

SOURCE_DATE_EPOCH=1748988170 flit build --setup-py --format sdist
Found 36 files tracked in git                                                                                      I-flit.sdist
Writing generated setup.py                                                                                         I-flit.sdist
Built sdist: dist/package-2.16.0.tar.gz                                                                       I-flit_core.sdist
> ll dist/
total 24K
-rw-r--r-- 1 savage admin 24K Jun  4 08:03 package-2.16.0.tar.gz
```
This change fixes that issue:
```
> make dist/package-2.16.0.tar.gz
...

echo 1748988267 > dist/package-2.16.0-build-epoch.txt
SOURCE_DATE_EPOCH=1748988267 flit build --setup-py --format sdist
Found 36 files tracked in git                                                                                      I-flit.sdist
Writing generated setup.py                                                                                         I-flit.sdist
Built sdist: dist/package-2.16.0.tar.gz                                                                       I-flit_core.sdist
> ll dist
total 28K
-rw-r--r-- 1 savage admin  11 Jun  4 08:04 package-2.16.0-build-epoch.txt
-rw-r--r-- 1 savage admin 24K Jun  4 08:04 package-2.16.0.tar.gz
> cat dist/package-2.16.0-build-epoch.txt 
1748988267
```
We could probably make this more readable by using a dedicated `build-epoch` goal or some such… 🤔

This actually becomes useful in combination with PR https://github.com/jenstroeger/python-package-template/pull/947 so that we can now use:
```
> make simple-index
```
which builds the packages, their epoch, and the `pip` Simple Repository.