### PR TITLE
fix: the generated sdist file should contain everything needed to check and test the code, and to build the documentation as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,19 +119,18 @@ omit = [
 ]
 
 
-# https://flit.pypa.io/en/latest/pyproject_toml.html#sdist-section
+# https://flit.pypa.io/en/stable/pyproject_toml.html#sdist-section
 # See also: https://github.com/pypa/flit/issues/565
+# See also: https://github.com/pypa/flit/discussions/745
 [tool.flit.sdist]
 include = []
 exclude = [
     ".github/",
-    "docs/",
-    "tests/",
-    ".flake8",
+    ".vscode/",
     ".gitignore",
-    ".pre-commit-config.yaml",
+    ".gitattributes",
     "CHANGELOG.md",
-    "Makefile",
+    "CODEOWNERS",
     "SECURITY.md",
 ]
 


### PR DESCRIPTION
This change supersedes PR https://github.com/jenstroeger/python-package-template/pull/948 based on discussion https://github.com/pypa/flit/discussions/745.

The generated sdist file now contains these files:
```
> tar -ztvf dist/package-2.16.0.tar.gz
-rw-r--r-- 0/0            1883 2025-07-01 06:30 package-2.16.0/.flake8
-rw-r--r-- 0/0            5035 2025-07-01 06:30 package-2.16.0/.pre-commit-config.yaml
-rw-r--r-- 0/0            1063 2025-07-01 06:30 package-2.16.0/LICENSE.md
-rw-r--r-- 0/0           11471 2025-07-01 06:30 package-2.16.0/Makefile
-rw-r--r-- 0/0           28836 2025-07-01 06:30 package-2.16.0/README.md
-rw-r--r-- 0/0             675 2025-07-01 06:30 package-2.16.0/docs/Makefile
-rw-r--r-- 0/0            2006 2025-07-01 06:30 package-2.16.0/docs/source/conf.py
-rw-r--r-- 0/0             816 2025-07-01 06:30 package-2.16.0/docs/source/index.rst
-rw-r--r-- 0/0            8226 2025-07-01 06:30 package-2.16.0/pyproject.toml
-rw-r--r-- 0/0             386 2025-07-01 06:30 package-2.16.0/src/package/__init__.py
-rw-r--r-- 0/0             496 2025-07-01 06:30 package-2.16.0/src/package/__main__.py
-rw-r--r-- 0/0              80 2025-07-01 06:30 package-2.16.0/src/package/py.typed
-rw-r--r-- 0/0             520 2025-07-01 06:30 package-2.16.0/src/package/something.py
-rw-r--r-- 0/0             615 2025-07-01 06:30 package-2.16.0/tests/conftest.py
-rw-r--r-- 0/0             686 2025-07-01 06:30 package-2.16.0/tests/test_something.py
-rw-r--r-- 0/0            1352 1970-01-01 10:00 package-2.16.0/setup.py
-rw-r--r-- 0/0           31320 1970-01-01 10:00 package-2.16.0/PKG-INFO
```
This is essentially a [git archive](https://git-scm.com/docs/git-archive) of the folder allowing somebody to build the package and documentation, to run all code checks, and to run the tests.

However, because this generated archive is _not_ a git folder but our development process assumes both git and [pre-commit](https://pre-commit.com/), the archive doesn’t quite work out of the box. I think it would be ok to remove Makefile and .pre-commit-config.yaml, and let the user figure out the rest?

Tagging @takluyver