### PR TITLE
fix: make sure isort skips over files listed as such in the pyproject.toml tool configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ profile = "black"
 multi_line_output = 3
 line_length = 120
 skip_gitignore = true
+filter_files = true
 
 
 # https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml


### PR DESCRIPTION
Thing is, we invoke `isort` via the pre-commit git hooks and that hook passes a list of files to `isort` in the command line. We now have to tell `isort` to filter those files by the settings in the configuration or else _all_ files will be sorted. For details see the [Filter files](https://pycqa.github.io/isort/docs/configuration/options.html#filter-files) section in the `isort` docs.