### PR TITLE
build: use head_commit object for checking the bump message

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check:
-    if: ${{ !startsWith(github.event.commits[0].message, 'bump:') }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'bump:') }}
     uses: ./.github/workflows/_build.yaml
     permissions:
       contents: read
@@ -77,7 +77,7 @@ jobs:
 
   # When triggered by the version bump commit, build the package and publish the release artifacts.
   build:
-    if: github.ref == 'refs/heads/release' && startsWith(github.event.commits[0].message, 'bump:')
+    if: github.ref == 'refs/heads/release' && startsWith(github.event.head_commit.message, 'bump:')
     uses: ./.github/workflows/_build.yaml
     permissions:
       contents: read


### PR DESCRIPTION
This PR uses the `head_commit` object from the [GitHub context object](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context) for checking the `bump` message. This approach provides a cleaner and more reliable way to detect version bump commits.