### PR TITLE
feat: add actions to CodeQL languages

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,9 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-        language: [python]
+        language: [python, actions]
         python: ['3.13']
     steps:
 


### PR DESCRIPTION
## Summary
This PR adds the `actions` scanner to the CodeQL configuration, which has been recently added to the supported languages.

It also removes `javascript` which was originally added for partial analysis of GitHub Actions. This is not required anymore.

See the latest set of supported languages [here](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed).