### PR TITLE
fix(deps): have Dependabot update the pre-commit hooks

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,6 @@
 # This configuration file enables Dependabot version updates.
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
+# https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories
 # https://github.com/dependabot/feedback/issues/551
 
 version: 2
@@ -20,6 +21,21 @@ updates:
   # -
 
 - package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  open-pull-requests-limit: 13
+  target-branch: main
+  # Add additional reviewers for PRs opened by Dependabot. For more information, see:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers
+  # reviewers:
+  #
+
+- package-ecosystem: pre-commit
   directory: /
   schedule:
     interval: weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
 # Commitizen enforces semantic and conventional commit messages.
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: 4fbeae7861663ecf4b4989211eba41c1a3fb1227  # v4.13.9
+  rev: 2ca29f9297911f8f5a4e8f97100b7832f045e8d3  # frozen: v4.13.10
   hooks:
   - id: commitizen
     name: Check conventional commit message
@@ -23,7 +23,7 @@ repos:
 
 # Sort imports.
 - repo: https://github.com/pycqa/isort
-  rev: a333737ed43df02b18e6c95477ea1b285b3de15a  # v8.0.1
+  rev: dac090ce4d9ee313d086e2e89ab1acb8c2664fa1  # frozen: 9.0.0a3
   hooks:
   - id: isort
     name: Sort import statements
@@ -32,13 +32,13 @@ repos:
 
 # Add Black code formatters.
 - repo: https://github.com/ambv/black
-  rev: c6755bb741b6481d6b3d3bb563c83fa060db96c9  # v26.3.1
+  rev: c6755bb741b6481d6b3d3bb563c83fa060db96c9  # frozen: 26.3.1
   hooks:
   - id: black
     name: Format code
     args: [--config, pyproject.toml]
 - repo: https://github.com/asottile/blacken-docs
-  rev: fda77690955e9b63c6687d8806bafd56a526e45f  # v1.20.0
+  rev: dda8db18cfc68df532abf33b185ecd12d5b7b326  # frozen: 1.20.0
   hooks:
   - id: blacken-docs
     name: Format code in docstrings
@@ -47,7 +47,7 @@ repos:
 
 # Upgrade and rewrite Python idioms.
 - repo: https://github.com/asottile/pyupgrade
-  rev: 75992aaa40730136014f34227e0135f63fc951b4  # v3.21.2
+  rev: 75992aaa40730136014f34227e0135f63fc951b4  # frozen: v3.21.2
   hooks:
   - id: pyupgrade
     name: Upgrade code idioms
@@ -57,7 +57,7 @@ repos:
 # Similar to pylint, with a few more/different checks. For more available
 # extensions: https://github.com/DmytroLitvinov/awesome-flake8-extensions
 - repo: https://github.com/pycqa/flake8
-  rev: c48217e1fc006c2dddd14df54e83b67da15de5cd  # v7.3.0
+  rev: d93590f5be797aabb60e3b09f2f52dddb02f349f  # frozen: 7.3.0
   hooks:
   - id: flake8
     name: Check flake8 issues
@@ -91,7 +91,7 @@ repos:
 
 # Check for potential security issues.
 - repo: https://github.com/PyCQA/bandit
-  rev: 92ae8b82fb422a639f0ed8d99e96cea769594e08  # v1.9.2
+  rev: 92ae8b82fb422a639f0ed8d99e96cea769594e08  # frozen: 1.9.4
   hooks:
   - id: bandit
     name: Check for security issues
@@ -103,7 +103,7 @@ repos:
 # Enable a whole bunch of useful helper hooks, too.
 # See https://pre-commit.com/hooks.html for more hooks.
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: check-ast
   - id: check-case-conflict
@@ -123,7 +123,7 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # v1.10.0
+  rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # frozen: v1.10.0
   hooks:
   - id: python-check-blanket-noqa
   - id: python-check-blanket-type-ignore
@@ -138,13 +138,13 @@ repos:
 # this package's documentation.
 # Commenting this out because https://github.com/Lucas-C/pre-commit-hooks-markup/issues/13
 # - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
-#   rev: 501f3d60cee13c712492103343bc23efdc7b3d1f  # v1.0.1
+#   rev: 501f3d60cee13c712492103343bc23efdc7b3d1f  # frozen: v1.0.1
 #   hooks:
 #   - id: rst-linter
 
 # Check and prettify the configuration files.
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: 4380fbb73a154b5f5624794c1c78d9719ccc860f  # v2.16.0
+  rev: 4380fbb73a154b5f5624794c1c78d9719ccc860f  # frozen: v2.16.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -156,7 +156,7 @@ repos:
 
 # Check GitHub Actions workflow files.
 - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-  rev: 2f3dbd354aa118b539dee99d8eed05a83097a199  # v1.7.12.24
+  rev: c04ed26e40637cab1aa9879c693832a9c120fb20  # frozen: v1.7.12.24
   hooks:
   - id: actionlint
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
 # Commitizen enforces semantic and conventional commit messages.
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.13.9
+  rev: 4fbeae7861663ecf4b4989211eba41c1a3fb1227  # v4.13.9
   hooks:
   - id: commitizen
     name: Check conventional commit message
@@ -23,7 +23,7 @@ repos:
 
 # Sort imports.
 - repo: https://github.com/pycqa/isort
-  rev: 7.0.0
+  rev: a333737ed43df02b18e6c95477ea1b285b3de15a  # v8.0.1
   hooks:
   - id: isort
     name: Sort import statements
@@ -32,22 +32,22 @@ repos:
 
 # Add Black code formatters.
 - repo: https://github.com/ambv/black
-  rev: 25.11.0
+  rev: c6755bb741b6481d6b3d3bb563c83fa060db96c9  # v26.3.1
   hooks:
   - id: black
     name: Format code
     args: [--config, pyproject.toml]
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.20.0
+  rev: fda77690955e9b63c6687d8806bafd56a526e45f  # v1.20.0
   hooks:
   - id: blacken-docs
     name: Format code in docstrings
     args: [--line-length, '120']
-    additional_dependencies: [black==25.11.0]
+    additional_dependencies: [black==26.3.1]
 
 # Upgrade and rewrite Python idioms.
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.21.2
+  rev: 75992aaa40730136014f34227e0135f63fc951b4  # v3.21.2
   hooks:
   - id: pyupgrade
     name: Upgrade code idioms
@@ -57,7 +57,7 @@ repos:
 # Similar to pylint, with a few more/different checks. For more available
 # extensions: https://github.com/DmytroLitvinov/awesome-flake8-extensions
 - repo: https://github.com/pycqa/flake8
-  rev: 7.3.0
+  rev: c48217e1fc006c2dddd14df54e83b67da15de5cd  # v7.3.0
   hooks:
   - id: flake8
     name: Check flake8 issues
@@ -91,7 +91,7 @@ repos:
 
 # Check for potential security issues.
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.9.2
+  rev: 92ae8b82fb422a639f0ed8d99e96cea769594e08  # v1.9.2
   hooks:
   - id: bandit
     name: Check for security issues
@@ -103,7 +103,7 @@ repos:
 # Enable a whole bunch of useful helper hooks, too.
 # See https://pre-commit.com/hooks.html for more hooks.
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
   hooks:
   - id: check-ast
   - id: check-case-conflict
@@ -123,7 +123,7 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.10.0
+  rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # v1.10.0
   hooks:
   - id: python-check-blanket-noqa
   - id: python-check-blanket-type-ignore
@@ -138,13 +138,13 @@ repos:
 # this package's documentation.
 # Commenting this out because https://github.com/Lucas-C/pre-commit-hooks-markup/issues/13
 # - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
-#   rev: v1.0.1
+#   rev: 501f3d60cee13c712492103343bc23efdc7b3d1f  # v1.0.1
 #   hooks:
 #   - id: rst-linter
 
 # Check and prettify the configuration files.
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.15.0
+  rev: 4380fbb73a154b5f5624794c1c78d9719ccc860f  # v2.16.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -156,7 +156,7 @@ repos:
 
 # Check GitHub Actions workflow files.
 - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-  rev: v1.7.9.24
+  rev: 2f3dbd354aa118b539dee99d8eed05a83097a199  # v1.7.12.24
   hooks:
   - id: actionlint
 


### PR DESCRIPTION
See also the [docs](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#pre-commit): Dependabot understands the pre-commit configuration and its additional dependencies ([docs](https://pre-commit.com/#config-additional_dependencies)).

Unfortunately, pre-commit for our hooks uses `pip` to install these additional dependencies and `pip`’s requirements specifiers do not support git hashes ([docs](https://pip.pypa.io/en/stable/reference/requirement-specifiers/)) such that the additional dependencies continue to use version tags.

This PR supersedes PR https://github.com/jenstroeger/python-package-template/pull/1122.