### PR TITLE
chore(deps): add documentation link to Dependabot configuration

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,4 +1,5 @@
 # Automatically merge Dependabot PRs upon approval.
+# https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request
 
 name: Automerge Dependabot PR
 on:


### PR DESCRIPTION
I thought this reference (and its alternative approach to auto-merging) is worthwhile keeping around… 🤔