### PR TITLE
fix(deps): add a 3-day cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,8 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 3
   commit-message:
     prefix: chore
     prefix-development: chore
@@ -24,6 +26,8 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 3
   commit-message:
     prefix: chore
     prefix-development: chore
@@ -39,6 +43,8 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 3
   commit-message:
     prefix: chore
     prefix-development: chore


### PR DESCRIPTION
I just made up the 3 days value, which seems somewhat safe-ish 😇