### PR TITLE
fix(deps): pin pytest until the pytest-cases plugin is getting fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ hooks = [
 test = [
     "faker ==40.19.1",
     "hypothesis >=6.21.0,<6.152.10",
-    "pytest >=9.0.3,<10.0.0",
+    "pytest >=9.0.3,<9.1.0",  # Pin until fixed: https://github.com/smarie/python-pytest-cases/issues/385
     "pytest-benchmark ==5.2.3",
     "pytest-cases ==3.10.1",
     "pytest-custom_exit_code ==0.3.0",


### PR DESCRIPTION
Pinning `pytest` until this issue is fixed: https://github.com/smarie/python-pytest-cases/issues/385