### PR TITLE
refactor: remove use of the twine package and instead use flit to publish to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,26 +149,16 @@ jobs:
         echo "release-tag=$TAG" >> "$GITHUB_OUTPUT"
         echo "release-url=$(gh release view """$TAG""" --json url --jq .url)" >> "$GITHUB_OUTPUT"
 
-    # Uncomment the following steps to publish to a PyPI server.
-    # At the moment PyPI does not provide a mechanism to publish
-    # the provenance. So, users have to download the provenance from
-    # the release page of the GitHub repository to verify the artifact.
-    # Install Twine without using the package's Makefile to avoid
-    # installing unnecessary dependencies, which is slow.
-    # - name: Set up Twine
-    #   run: |
-    #     pip install --upgrade pip wheel
-    #     pip install 'twine ==4.0.2'
-
     # Pass the username, password, and PYPI repository URL via env variables.
     # Read the password from GitHub secrets or via other trusted mechanisms.
     # Do not hardcode the password in the workflow.
+    # https://flit.pypa.io/en/stable/upload.html
     # - name: Publish to PyPI server
-    #   run: twine upload --verbose --skip-existing dist/*.tar.gz dist/*.whl
+    #   run: python -m flit publish
     #   env:
-    #     TWINE_USERNAME=<USERNAME>
-    #     TWINE_PASSWORD=<PASSWORD>
-    #     TWINE_REPOSITORY_URL=<REPOSITORY_URL>
+    #     FLIT_USERNAME=<USERNAME>
+    #     FLIT_PASSWORD=<PASSWORD>
+    #     FLIT_INDEX_URL=<PACKAGE_INDEX_URL>
 
   # Generate the build provenance. The generator should be referenced with a semantic version.
   # The build will fail if we reference it using the commit SHA. To avoid using a pre-built

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 # https://flit.pypa.io/en/latest/pyproject_toml.html
 [build-system]
-requires = ["flit_core >=3.12.0,<4.0.0"]
+requires = ["flit_core >=4.0.0,<4.1.0"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -44,7 +44,6 @@ something = "package.__main__:main"
 # installed. Make sure to keep the requirements in sync with the workflows!
 actions = [
     "commitizen ==4.16.4",
-    "twine ==6.2.0",
 ]
 dev = [
     "flit >=3.2.0,<4.0.0",


### PR DESCRIPTION
@behnazh does it make sense to drop the [twine](https://github.com/pypa/twine) dependency and use [flit](https://github.com/pypa/flit) for publishing instead? I think this really is just a minor detail although, there’s issue https://github.com/pypa/flit/issues/709 🤔

Also, this PR currently breaks because of issue https://github.com/pypa/flit/issues/811