### PR TITLE
chore: remove unnecessary cmd line flag from `rm` in a Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ clean: dist-clean
 # Remove code caches, or the entire virtual environment.
 .PHONY: nuke-git-hooks nuke-caches nuke
 nuke-git-hooks:
-	find .git/hooks/ -type f ! -name '*.sample' -exec rm -fr {} +
+	find .git/hooks/ -type f ! -name '*.sample' -exec rm -f {} +
 nuke-caches:
 	find src/ -type d -name __pycache__ -exec rm -fr {} +
 	find tests/ -type d -name __pycache__ -exec rm -fr {} +


### PR DESCRIPTION
Because `find` finds _files_ so we don’t need the `-r` when `rm`’ing the found files.