### PR TITLE
fix(deps): pin `flit_core` to match the already pinned `flit` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ docs = [
 dist = [
     "cyclonedx-bom >=7.0.0,<8.0.0",
     "flit >=3.2.0,<4.0.0",
+    "flit_core >=3.2.0,<4.0.0",
 ]
 hooks = [
     "pre-commit >=4.0.0,<4.7.0",


### PR DESCRIPTION
It looks like `flit_core` is now — as of yesterday, actually, see [tags](https://github.com/pypa/flit/tags) — available on PyPI as v4 and that collides with the existing `flit <4` dependency range… so we need to pin both.

For reference see https://github.com/pypa/flit/issues/811#issuecomment-5195444405 and [Allow package references as version specifiers](https://discuss.python.org/t/allow-package-references-as-version-specifiers/19226).